### PR TITLE
add media keys (PlayPause, Stop, PrevTrack, NextTrack) (windows only unfortunately)

### DIFF
--- a/src/platform/windows/keycode.rs
+++ b/src/platform/windows/keycode.rs
@@ -147,6 +147,12 @@ pub fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
         0x38 => Some(Key::Num8),
         0x39 => Some(Key::Num9),
 
+        // Media keys
+        0xB3 => Some(Key::PlayPause),
+        0xB2 => Some(Key::Stop),
+        0xB1 => Some(Key::PrevTrack),
+        0xB0 => Some(Key::NextTrack),
+
         // Numpad keys - these are always distinct from main keys
         vk::NUMPAD0 => Some(Key::Keypad0),
         vk::NUMPAD1 => Some(Key::Keypad1),

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -50,6 +50,12 @@ pub enum Key {
     Num8,
     Num9,
 
+    // Media keys
+    PlayPause,
+    Stop,
+    PrevTrack,
+    NextTrack,
+
     // Function keys
     F1,
     F2,
@@ -185,6 +191,10 @@ impl fmt::Display for Key {
             Key::Num7 => write!(f, "7"),
             Key::Num8 => write!(f, "8"),
             Key::Num9 => write!(f, "9"),
+            Key::PlayPause => write!(f, "PlayPause"),
+            Key::Stop => write!(f, "Stop"),
+            Key::PrevTrack => write!(f, "PrevTrack"),
+            Key::NextTrack => write!(f, "NextTrack"),
             Key::F1 => write!(f, "F1"),
             Key::F2 => write!(f, "F2"),
             Key::F3 => write!(f, "F3"),
@@ -313,6 +323,12 @@ impl FromStr for Key {
             "7" | "num7" => Ok(Key::Num7),
             "8" | "num8" => Ok(Key::Num8),
             "9" | "num9" => Ok(Key::Num9),
+
+            // Media keys
+            "playpause" => Ok(Key::PlayPause),
+            "stop" => Ok(Key::Stop),
+            "prevtrack" => Ok(Key::PrevTrack),
+            "nexttrack" => Ok(Key::NextTrack),
 
             // Function keys
             "f1" => Ok(Key::F1),

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -560,6 +560,10 @@ mod tests {
             Key::JisEisu,
             Key::JisKana,
             Key::Dictation,
+            Key::PlayPause,
+            Key::Stop,
+            Key::PrevTrack,
+            Key::NextTrack,
         ];
         for key in keys {
             let displayed = format!("{}", key);
@@ -575,5 +579,15 @@ mod tests {
         assert_eq!("globe".parse::<Key>().unwrap(), Key::Dictation);
         // "fn" must keep parsing as the Fn *modifier*, not a key
         assert!("fn".parse::<Key>().is_err());
+    }
+
+    #[test]
+    fn parse_media_keys() {
+        // Parsing is case-insensitive and matches the Display spelling.
+        assert_eq!("playpause".parse::<Key>().unwrap(), Key::PlayPause);
+        assert_eq!("PlayPause".parse::<Key>().unwrap(), Key::PlayPause);
+        assert_eq!("stop".parse::<Key>().unwrap(), Key::Stop);
+        assert_eq!("prevtrack".parse::<Key>().unwrap(), Key::PrevTrack);
+        assert_eq!("nexttrack".parse::<Key>().unwrap(), Key::NextTrack);
     }
 }

--- a/tests/synthetic_input.rs
+++ b/tests/synthetic_input.rs
@@ -96,7 +96,8 @@ mod windows_tests {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
         KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE, MOUSEINPUT, MOUSEEVENTF_MIDDLEUP, MOUSE_EVENT_FLAGS,
-        VIRTUAL_KEY, VK_F20,
+        VIRTUAL_KEY, VK_F20, VK_MEDIA_NEXT_TRACK, VK_MEDIA_PLAY_PAUSE, VK_MEDIA_PREV_TRACK,
+        VK_MEDIA_STOP,
     };
 
     fn send_f20(key_up: bool) {
@@ -229,5 +230,49 @@ mod windows_tests {
             saw_key_event(&listener, Key::MouseMiddle, false, Duration::from_secs(2)),
             "did not observe injected middle-button-up as Key::MouseMiddle"
         );
+    }
+
+    /// Inject a lone key-up for a virtual key. Media actions (play/pause,
+    /// skip) fire on key-*down*, so a lone key-up is still observed by the
+    /// hook without actually controlling any media in the running session.
+    fn send_vk_key_up(vk: VIRTUAL_KEY) {
+        let input = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: vk,
+                    wScan: 0,
+                    dwFlags: KEYEVENTF_KEYUP,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let sent = unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32) };
+        assert_eq!(sent, 1, "SendInput failed");
+    }
+
+    /// The four media virtual-keys map to their `Key` variants through the
+    /// real WH_KEYBOARD_LL path. Only reaches the hook when the keyboard/driver
+    /// delivers media keys as VK codes (not as WM_APPCOMMAND) — see TESTING.md.
+    #[test]
+    #[ignore = "needs an interactive desktop session; run: cargo test --test synthetic_input -- --ignored"]
+    fn injected_media_keys_reach_listener() {
+        let listener = KeyboardListener::new().expect("failed to spawn keyboard listener");
+        std::thread::sleep(Duration::from_millis(200));
+
+        for (vk, key) in [
+            (VK_MEDIA_PLAY_PAUSE, Key::PlayPause),
+            (VK_MEDIA_STOP, Key::Stop),
+            (VK_MEDIA_PREV_TRACK, Key::PrevTrack),
+            (VK_MEDIA_NEXT_TRACK, Key::NextTrack),
+        ] {
+            send_vk_key_up(vk);
+            assert!(
+                saw_key_event(&listener, key, false, Duration::from_secs(2)),
+                "did not observe injected media key {key} (vk {:#04x})",
+                vk.0
+            );
+        }
     }
 }


### PR DESCRIPTION
adds support for the media control keys! (windows only unfortunately)

my testing across a few laptops has shown that the libraries used for macos/linux do not pick up the media keys correctly if at all.
as such, i can understand if this pr will be rejected to keep behavior consistent across platforms

tests: 46 pass, 0 fail
