### PR TITLE
fix(macos): strip FN modifier from function key events (F1-F20)

### DIFF
--- a/src/platform/macos/listener.rs
+++ b/src/platform/macos/listener.rs
@@ -158,6 +158,17 @@ unsafe extern "C-unwind" fn event_tap_callback(
                     return event.as_ptr();
                 }
 
+                // On macOS, strip FN from function key events (F1-F20). The fn key
+                // is required to access F-keys when the keyboard is in default "media
+                // keys" mode, but it's a transport mechanism — not a meaningful
+                // modifier. Stripping it ensures that a hotkey registered as "f5"
+                // matches regardless of the user's keyboard configuration.
+                let modifiers = if key.map_or(false, |k| k.is_function_key()) {
+                    modifiers & !Modifiers::FN
+                } else {
+                    modifiers
+                };
+
                 // Check if this should be blocked
                 should_block = state.should_block(modifiers, key);
 
@@ -180,6 +191,13 @@ unsafe extern "C-unwind" fn event_tap_callback(
                 if key.is_none() && flags_have_fn(flags) {
                     return event.as_ptr();
                 }
+
+                // Strip FN from function key events (same rationale as KeyDown)
+                let modifiers = if key.map_or(false, |k| k.is_function_key()) {
+                    modifiers & !Modifiers::FN
+                } else {
+                    modifiers
+                };
 
                 // Block key up if we blocked key down (to be consistent)
                 should_block = state.should_block(modifiers, key);

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -146,6 +146,42 @@ pub enum Key {
     MouseX2,
 }
 
+impl Key {
+    /// Returns `true` if this key is a function key (F1–F20).
+    ///
+    /// On macOS, function keys require holding `fn` when the keyboard is in
+    /// default "media keys" mode. The `fn` key sets the `FN` modifier flag,
+    /// but it acts as a transport mechanism — not a meaningful modifier.
+    /// This helper is used to strip FN from function key events so that a
+    /// hotkey registered as `"f5"` matches regardless of the user's keyboard
+    /// configuration.
+    pub fn is_function_key(self) -> bool {
+        matches!(
+            self,
+            Key::F1
+                | Key::F2
+                | Key::F3
+                | Key::F4
+                | Key::F5
+                | Key::F6
+                | Key::F7
+                | Key::F8
+                | Key::F9
+                | Key::F10
+                | Key::F11
+                | Key::F12
+                | Key::F13
+                | Key::F14
+                | Key::F15
+                | Key::F16
+                | Key::F17
+                | Key::F18
+                | Key::F19
+                | Key::F20
+        )
+    }
+}
+
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -509,5 +545,21 @@ mod tests {
             let parsed: Key = displayed.parse().unwrap();
             assert_eq!(parsed, key, "Roundtrip failed for {:?}", key);
         }
+    }
+
+    #[test]
+    fn is_function_key() {
+        // F1-F20 are function keys
+        assert!(Key::F1.is_function_key());
+        assert!(Key::F5.is_function_key());
+        assert!(Key::F12.is_function_key());
+        assert!(Key::F20.is_function_key());
+
+        // Everything else is not
+        assert!(!Key::A.is_function_key());
+        assert!(!Key::Space.is_function_key());
+        assert!(!Key::Num5.is_function_key());
+        assert!(!Key::Escape.is_function_key());
+        assert!(!Key::MouseLeft.is_function_key());
     }
 }


### PR DESCRIPTION
## Summary

On macOS, function keys (F1-F20) can't be used as hotkeys because the `fn` key's modifier flag causes a matching mismatch.

### Root Cause

When the keyboard is in default "media keys" mode (the default on all Mac laptops), pressing F5 requires holding `fn`. This sets `CGEventFlags::MaskSecondaryFn`, which handy-keys reports as the `FN` modifier. Since `Modifiers::matches()` does exact matching on FN:

```rust
// FN: exact match
self.contains(Modifiers::FN) == event.contains(Modifiers::FN)
```

A hotkey registered as `"f5"` (no FN) never matches an `fn+F5` event (which has FN set). Conversely, `"fn+f5"` won't match on keyboards with "standard function keys" mode enabled.

### Fix

Strips the FN modifier from `KeyDown`/`KeyUp` events in the macOS listener when the key is a recognized function key (F1-F20). The `fn` key is a transport mechanism to access F-keys, not a meaningful modifier.

**Changes:**
- `Key::is_function_key()` — new public helper method
- `platform/macos/listener.rs` — strip FN from modifiers for function key KeyDown/KeyUp events

**Behavior after fix:**
- `"f5"` matches both `fn+F5` (media keys mode) and `F5` (standard mode)
- `"cmd+f5"` matches both `Cmd+fn+F5` and `Cmd+F5`
- Recording captures `"F5"` instead of `"fn+F5"`
- Non-function-key shortcuts using FN (e.g., `"fn+space"`) are unaffected

### Context

This was reported in [Handy](https://github.com/cjpais/Handy), which uses handy-keys for keyboard shortcut handling. The F5 key (mic/dictation key on MacBooks) is a natural choice for a speech-to-text shortcut but was completely unusable. Fixing this at the library level benefits all handy-keys consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)