### PR TITLE
macos: support Voice Command key

### DIFF
--- a/src/platform/macos/keycode.rs
+++ b/src/platform/macos/keycode.rs
@@ -123,6 +123,7 @@ mod keycodes {
     pub const RIGHT_ARROW: u16 = 0x7C;
     pub const DOWN_ARROW: u16 = 0x7D;
     pub const UP_ARROW: u16 = 0x7E;
+    pub const VOICE: u16 = 0xB0;
 }
 
 /// Convert a macOS virtual keycode to a Key enum
@@ -184,6 +185,7 @@ pub fn keycode_to_key(keycode: CGKeyCode) -> Option<Key> {
         keycodes::F18 => Some(Key::F18),
         keycodes::F19 => Some(Key::F19),
         keycodes::F20 => Some(Key::F20),
+        keycodes::VOICE => Some(Key::Voice),
         keycodes::SPACE => Some(Key::Space),
         keycodes::RETURN => Some(Key::Return),
         keycodes::TAB => Some(Key::Tab),

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -72,6 +72,9 @@ pub enum Key {
     F19,
     F20,
 
+    // Media keys
+    Voice,
+
     // Special keys
     Space,
     Return,
@@ -205,6 +208,7 @@ impl fmt::Display for Key {
             Key::F18 => write!(f, "F18"),
             Key::F19 => write!(f, "F19"),
             Key::F20 => write!(f, "F20"),
+            Key::Voice => write!(f, "Voice"),
             Key::Space => write!(f, "Space"),
             Key::Return => write!(f, "Return"),
             Key::Tab => write!(f, "Tab"),
@@ -335,6 +339,9 @@ impl FromStr for Key {
             "f18" => Ok(Key::F18),
             "f19" => Ok(Key::F19),
             "f20" => Ok(Key::F20),
+
+            // Media keys
+            "voice" => Ok(Key::Voice),
 
             // Special keys
             "space" | " " => Ok(Key::Space),


### PR DESCRIPTION
Allow Handy to use Voice Command key (F5/Microphone) as a shortcut. 

The HID key code 0xc000000cf encodes Voice Command (0xCF) from Consumer Page (0x0C) of HID Usage Tables 1.7. 

The CGEvent key code is different, I assume it is a virtual key dedicated for this button but I could not find it anywhere in the header files.

One minor issue is that hotkey will be displayed as `fn + Voice` but the same happens for F-keys even when "Use F1, F2, etc keys as standard function keys" option is enabled.

<img width="1584" height="1364" alt="image" src="https://github.com/user-attachments/assets/db42b8cc-3097-4f2e-8a97-f1e64ad11b0a" />

See related https://github.com/cjpais/Handy/discussions/1026