### PR TITLE
feat(linux): add read-only evdev backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ version = "0.2.4"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
+ "evdev-rs",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ categories = ["api-bindings", "os"]
 name = "handy_keys"
 path = "src/lib.rs"
 
+[features]
+default = ["linux-rdev-grab"]
+linux-rdev-grab = ["dep:rdev"]
+linux-evdev-readonly = ["dep:evdev-rs"]
+
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
@@ -42,4 +47,5 @@ windows = { version = "0.58", features = [
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rdev = { version = "0.5.3", features = ["unstable_grab"] }
+rdev = { version = "0.5.3", features = ["unstable_grab"], optional = true }
+evdev-rs = { version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Uses low-level keyboard hooks. No special permissions required.
 
 Uses [rdev](https://crates.io/crates/rdev). On Wayland, hotkey blocking may not work due to compositor restrictions.
 
+An opt-in read-only evdev backend is available for Linux builds:
+
+```toml
+handy-keys = { version = "0.2", default-features = false, features = ["linux-evdev-readonly"] }
+```
+
+The evdev backend observes global key events but does not block them from reaching other applications, including when
+using `new_with_blocking`. It scans input devices at startup and requires read access to `/dev/input/event*` devices,
+typically via udev ACLs or the `input` group.
+
 ## Modifiers
 
 | Modifier | Aliases |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,11 @@
 //!
 //! Uses [rdev](https://crates.io/crates/rdev). On Wayland, hotkey blocking may not
 //! work due to compositor restrictions.
+//!
+//! An opt-in read-only evdev backend is available with the `linux-evdev-readonly`
+//! feature. It observes global key events but does not block them from reaching
+//! other applications, including when using `new_with_blocking`. It scans input
+//! devices at startup and requires read access to `/dev/input/event*` devices.
 
 mod error;
 mod listener;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -7,8 +7,9 @@
 //!
 //! - **macOS**: Uses CGEventTap. Requires accessibility permissions.
 //! - **Windows**: Uses low-level keyboard hooks. Clean thread shutdown.
-//! - **Linux**: Uses rdev. On Wayland, blocking may not work due to
-//!   compositor restrictions. Thread cleanup is limited.
+//! - **Linux**: Uses rdev by default. On Wayland, blocking may not work due to
+//!   compositor restrictions. The `linux-evdev-readonly` feature observes events
+//!   but cannot block them. Thread cleanup is limited.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, TryRecvError};
@@ -45,10 +46,12 @@ impl KeyboardListener {
     /// Create a new KeyboardListener with blocking support
     ///
     /// Events matching hotkeys in the provided set will be blocked from reaching
-    /// other applications. The set can be modified after creation to add/remove
-    /// hotkeys dynamically.
+    /// other applications when the active platform backend supports blocking.
+    /// The set can be modified after creation to add/remove hotkeys dynamically.
     ///
     /// Note: On Wayland, blocking may not work due to compositor restrictions.
+    /// When built with `linux-evdev-readonly`, Linux observes events but never
+    /// blocks them.
     pub fn new_with_blocking(blocking_hotkeys: BlockingHotkeys) -> Result<Self> {
         Self::new_internal(Some(blocking_hotkeys))
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -82,8 +82,10 @@ impl ManagerState {
 /// This manager wraps a `KeyboardListener` and filters events against
 /// registered hotkeys, emitting `HotkeyEvent`s when matches occur.
 ///
-/// Registered hotkeys are blocked from reaching other applications.
-/// Note: On Linux/Wayland, blocking may not work due to compositor restrictions.
+/// Registered hotkeys are blocked from reaching other applications when the
+/// active platform backend supports blocking. On Linux/Wayland, blocking may not
+/// work due to compositor restrictions. When built with `linux-evdev-readonly`,
+/// Linux observes events but never blocks them.
 pub struct HotkeyManager {
     state: Arc<Mutex<ManagerState>>,
     event_receiver: Receiver<HotkeyEvent>,
@@ -123,9 +125,12 @@ impl HotkeyManager {
     /// Create a new HotkeyManager with blocking support
     ///
     /// On macOS, this will check for accessibility permissions and fail if not granted.
-    /// Registered hotkeys will be blocked from reaching other applications.
+    /// Registered hotkeys will be blocked from reaching other applications when
+    /// the active platform backend supports blocking.
     ///
     /// Note: On Linux/Wayland, blocking may not work due to compositor restrictions.
+    /// When built with `linux-evdev-readonly`, Linux observes events but never
+    /// blocks them.
     pub fn new_with_blocking() -> Result<Self> {
         let blocking_hotkeys: BlockingHotkeys = Arc::new(Mutex::new(HashSet::new()));
         let listener = KeyboardListener::new_with_blocking(blocking_hotkeys.clone())?;

--- a/src/platform/linux/keycode_evdev.rs
+++ b/src/platform/linux/keycode_evdev.rs
@@ -1,0 +1,184 @@
+//! Linux key conversion utilities for evdev key codes.
+
+use crate::types::{Key, Modifiers};
+use evdev_rs::enums::EV_KEY;
+
+/// Convert an evdev key code to our Key type.
+pub fn evdev_key_to_key(key: &EV_KEY) -> Option<Key> {
+    match key {
+        EV_KEY::KEY_A => Some(Key::A),
+        EV_KEY::KEY_B => Some(Key::B),
+        EV_KEY::KEY_C => Some(Key::C),
+        EV_KEY::KEY_D => Some(Key::D),
+        EV_KEY::KEY_E => Some(Key::E),
+        EV_KEY::KEY_F => Some(Key::F),
+        EV_KEY::KEY_G => Some(Key::G),
+        EV_KEY::KEY_H => Some(Key::H),
+        EV_KEY::KEY_I => Some(Key::I),
+        EV_KEY::KEY_J => Some(Key::J),
+        EV_KEY::KEY_K => Some(Key::K),
+        EV_KEY::KEY_L => Some(Key::L),
+        EV_KEY::KEY_M => Some(Key::M),
+        EV_KEY::KEY_N => Some(Key::N),
+        EV_KEY::KEY_O => Some(Key::O),
+        EV_KEY::KEY_P => Some(Key::P),
+        EV_KEY::KEY_Q => Some(Key::Q),
+        EV_KEY::KEY_R => Some(Key::R),
+        EV_KEY::KEY_S => Some(Key::S),
+        EV_KEY::KEY_T => Some(Key::T),
+        EV_KEY::KEY_U => Some(Key::U),
+        EV_KEY::KEY_V => Some(Key::V),
+        EV_KEY::KEY_W => Some(Key::W),
+        EV_KEY::KEY_X => Some(Key::X),
+        EV_KEY::KEY_Y => Some(Key::Y),
+        EV_KEY::KEY_Z => Some(Key::Z),
+
+        EV_KEY::KEY_0 => Some(Key::Num0),
+        EV_KEY::KEY_1 => Some(Key::Num1),
+        EV_KEY::KEY_2 => Some(Key::Num2),
+        EV_KEY::KEY_3 => Some(Key::Num3),
+        EV_KEY::KEY_4 => Some(Key::Num4),
+        EV_KEY::KEY_5 => Some(Key::Num5),
+        EV_KEY::KEY_6 => Some(Key::Num6),
+        EV_KEY::KEY_7 => Some(Key::Num7),
+        EV_KEY::KEY_8 => Some(Key::Num8),
+        EV_KEY::KEY_9 => Some(Key::Num9),
+
+        EV_KEY::KEY_F1 => Some(Key::F1),
+        EV_KEY::KEY_F2 => Some(Key::F2),
+        EV_KEY::KEY_F3 => Some(Key::F3),
+        EV_KEY::KEY_F4 => Some(Key::F4),
+        EV_KEY::KEY_F5 => Some(Key::F5),
+        EV_KEY::KEY_F6 => Some(Key::F6),
+        EV_KEY::KEY_F7 => Some(Key::F7),
+        EV_KEY::KEY_F8 => Some(Key::F8),
+        EV_KEY::KEY_F9 => Some(Key::F9),
+        EV_KEY::KEY_F10 => Some(Key::F10),
+        EV_KEY::KEY_F11 => Some(Key::F11),
+        EV_KEY::KEY_F12 => Some(Key::F12),
+        EV_KEY::KEY_F13 => Some(Key::F13),
+        EV_KEY::KEY_F14 => Some(Key::F14),
+        EV_KEY::KEY_F15 => Some(Key::F15),
+        EV_KEY::KEY_F16 => Some(Key::F16),
+        EV_KEY::KEY_F17 => Some(Key::F17),
+        EV_KEY::KEY_F18 => Some(Key::F18),
+        EV_KEY::KEY_F19 => Some(Key::F19),
+        EV_KEY::KEY_F20 => Some(Key::F20),
+
+        EV_KEY::KEY_SPACE => Some(Key::Space),
+        EV_KEY::KEY_ENTER => Some(Key::Return),
+        EV_KEY::KEY_TAB => Some(Key::Tab),
+        EV_KEY::KEY_ESC => Some(Key::Escape),
+        EV_KEY::KEY_BACKSPACE => Some(Key::Delete),
+        EV_KEY::KEY_DELETE => Some(Key::ForwardDelete),
+        EV_KEY::KEY_INSERT => Some(Key::Insert),
+        EV_KEY::KEY_HOME => Some(Key::Home),
+        EV_KEY::KEY_END => Some(Key::End),
+        EV_KEY::KEY_PAGEUP => Some(Key::PageUp),
+        EV_KEY::KEY_PAGEDOWN => Some(Key::PageDown),
+        EV_KEY::KEY_LEFT => Some(Key::LeftArrow),
+        EV_KEY::KEY_RIGHT => Some(Key::RightArrow),
+        EV_KEY::KEY_UP => Some(Key::UpArrow),
+        EV_KEY::KEY_DOWN => Some(Key::DownArrow),
+
+        EV_KEY::KEY_MINUS => Some(Key::Minus),
+        EV_KEY::KEY_EQUAL => Some(Key::Equal),
+        EV_KEY::KEY_LEFTBRACE => Some(Key::LeftBracket),
+        EV_KEY::KEY_RIGHTBRACE => Some(Key::RightBracket),
+        EV_KEY::KEY_BACKSLASH => Some(Key::Backslash),
+        EV_KEY::KEY_SEMICOLON => Some(Key::Semicolon),
+        EV_KEY::KEY_APOSTROPHE => Some(Key::Quote),
+        EV_KEY::KEY_COMMA => Some(Key::Comma),
+        EV_KEY::KEY_DOT => Some(Key::Period),
+        EV_KEY::KEY_SLASH => Some(Key::Slash),
+        EV_KEY::KEY_GRAVE => Some(Key::Grave),
+        EV_KEY::KEY_102ND => Some(Key::Section),
+
+        EV_KEY::KEY_KP0 => Some(Key::Keypad0),
+        EV_KEY::KEY_KP1 => Some(Key::Keypad1),
+        EV_KEY::KEY_KP2 => Some(Key::Keypad2),
+        EV_KEY::KEY_KP3 => Some(Key::Keypad3),
+        EV_KEY::KEY_KP4 => Some(Key::Keypad4),
+        EV_KEY::KEY_KP5 => Some(Key::Keypad5),
+        EV_KEY::KEY_KP6 => Some(Key::Keypad6),
+        EV_KEY::KEY_KP7 => Some(Key::Keypad7),
+        EV_KEY::KEY_KP8 => Some(Key::Keypad8),
+        EV_KEY::KEY_KP9 => Some(Key::Keypad9),
+        EV_KEY::KEY_KPDOT => Some(Key::KeypadDecimal),
+        EV_KEY::KEY_KPASTERISK => Some(Key::KeypadMultiply),
+        EV_KEY::KEY_KPPLUS => Some(Key::KeypadPlus),
+        EV_KEY::KEY_KPSLASH => Some(Key::KeypadDivide),
+        EV_KEY::KEY_KPENTER => Some(Key::KeypadEnter),
+        EV_KEY::KEY_KPMINUS => Some(Key::KeypadMinus),
+        EV_KEY::KEY_KPEQUAL => Some(Key::KeypadEquals),
+        EV_KEY::KEY_KPCOMMA | EV_KEY::KEY_KPJPCOMMA => Some(Key::KeypadComma),
+
+        EV_KEY::KEY_CAPSLOCK => Some(Key::CapsLock),
+        EV_KEY::KEY_SCROLLLOCK => Some(Key::ScrollLock),
+        EV_KEY::KEY_NUMLOCK => Some(Key::NumLock),
+
+        EV_KEY::BTN_LEFT => Some(Key::MouseLeft),
+        EV_KEY::BTN_RIGHT => Some(Key::MouseRight),
+        EV_KEY::BTN_MIDDLE => Some(Key::MouseMiddle),
+        EV_KEY::BTN_SIDE => Some(Key::MouseX1),
+        EV_KEY::BTN_EXTRA => Some(Key::MouseX2),
+
+        _ => None,
+    }
+}
+
+/// Convert an evdev modifier key to our side-specific Modifiers type.
+pub fn evdev_key_to_modifier(key: &EV_KEY) -> Option<Modifiers> {
+    match key {
+        EV_KEY::KEY_LEFTSHIFT => Some(Modifiers::SHIFT_LEFT),
+        EV_KEY::KEY_RIGHTSHIFT => Some(Modifiers::SHIFT_RIGHT),
+        EV_KEY::KEY_LEFTCTRL => Some(Modifiers::CTRL_LEFT),
+        EV_KEY::KEY_RIGHTCTRL => Some(Modifiers::CTRL_RIGHT),
+        EV_KEY::KEY_LEFTALT => Some(Modifiers::OPT_LEFT),
+        EV_KEY::KEY_RIGHTALT => Some(Modifiers::OPT_RIGHT),
+        EV_KEY::KEY_LEFTMETA => Some(Modifiers::CMD_LEFT),
+        EV_KEY::KEY_RIGHTMETA => Some(Modifiers::CMD_RIGHT),
+        _ => None,
+    }
+}
+
+/// Update modifier state based on an evdev key event.
+pub fn update_modifiers(current: Modifiers, key: &EV_KEY, pressed: bool) -> Modifiers {
+    let Some(modifier) = evdev_key_to_modifier(key) else {
+        return current;
+    };
+
+    if pressed {
+        current | modifier
+    } else {
+        current & !modifier
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_common_keyboard_keys() {
+        assert_eq!(evdev_key_to_key(&EV_KEY::KEY_A), Some(Key::A));
+        assert_eq!(evdev_key_to_key(&EV_KEY::KEY_SPACE), Some(Key::Space));
+        assert_eq!(evdev_key_to_key(&EV_KEY::KEY_INSERT), Some(Key::Insert));
+    }
+
+    #[test]
+    fn maps_mouse_buttons() {
+        assert_eq!(evdev_key_to_key(&EV_KEY::BTN_LEFT), Some(Key::MouseLeft));
+        assert_eq!(evdev_key_to_key(&EV_KEY::BTN_EXTRA), Some(Key::MouseX2));
+    }
+
+    #[test]
+    fn tracks_side_specific_modifiers() {
+        let modifiers = update_modifiers(Modifiers::empty(), &EV_KEY::KEY_RIGHTALT, true);
+        assert!(modifiers.contains(Modifiers::OPT_RIGHT));
+        assert!(Modifiers::OPT.matches(modifiers));
+
+        let modifiers = update_modifiers(modifiers, &EV_KEY::KEY_RIGHTALT, false);
+        assert!(modifiers.is_empty());
+    }
+}

--- a/src/platform/linux/listener_evdev.rs
+++ b/src/platform/linux/listener_evdev.rs
@@ -1,0 +1,251 @@
+//! Linux keyboard listener using read-only evdev device streams.
+//!
+//! This backend does not grab devices. It observes global key events, but it
+//! cannot block registered hotkeys from reaching other applications.
+//! Devices are discovered once at listener startup.
+
+use std::fs::{read_dir, File};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use evdev_rs::enums::{EventCode, EV_KEY};
+use evdev_rs::{Device, InputEvent, ReadFlag};
+
+use crate::error::{Error, Result};
+use crate::platform::state::{BlockingHotkeys, ListenerState};
+use crate::types::{Key, KeyEvent, Modifiers};
+
+use super::keycode::{evdev_key_to_key, evdev_key_to_modifier, update_modifiers};
+
+const DEV_INPUT: &str = "/dev/input";
+
+/// Internal listener state returned to KeyboardListener.
+pub(crate) struct LinuxListenerState {
+    pub event_receiver: Receiver<KeyEvent>,
+    pub thread_handle: Option<JoinHandle<()>>,
+    pub running: Arc<AtomicBool>,
+    pub blocking_hotkeys: Option<BlockingHotkeys>,
+}
+
+/// Spawn a read-only evdev keyboard listener for Linux.
+pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<LinuxListenerState> {
+    if blocking_hotkeys.is_some() {
+        eprintln!("handy-keys: linux-evdev-readonly observes hotkeys but does not block them");
+    }
+
+    let files = get_device_files(DEV_INPUT)?;
+    if files.is_empty() {
+        return Err(Error::Platform(
+            "no readable /dev/input/event* devices found; evdev requires input device read access"
+                .into(),
+        ));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let state = Arc::new(Mutex::new(ListenerState::new(tx)));
+    let running = Arc::new(AtomicBool::new(true));
+
+    let thread_state = Arc::clone(&state);
+    let thread_running = Arc::clone(&running);
+
+    let handle = thread::spawn(move || {
+        for file in files {
+            spawn_device_reader(file, Arc::clone(&thread_state), Arc::clone(&thread_running));
+        }
+
+        while thread_running.load(Ordering::SeqCst) {
+            thread::sleep(Duration::from_secs(1));
+        }
+    });
+
+    Ok(LinuxListenerState {
+        event_receiver: rx,
+        thread_handle: Some(handle),
+        running,
+        blocking_hotkeys,
+    })
+}
+
+fn spawn_device_reader(file: File, state: Arc<Mutex<ListenerState>>, running: Arc<AtomicBool>) {
+    thread::spawn(move || {
+        let device = match Device::new_from_fd(file) {
+            Ok(device) => device,
+            Err(error) => {
+                eprintln!("handy-keys: skipping unreadable input device: {error}");
+                return;
+            }
+        };
+
+        while running.load(Ordering::SeqCst) {
+            match device.next_event(ReadFlag::NORMAL | ReadFlag::BLOCKING) {
+                Ok((_, event)) => handle_input_event(&event, &state),
+                Err(error) => {
+                    if running.load(Ordering::SeqCst) {
+                        eprintln!("handy-keys: input device reader stopped: {error}");
+                    }
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn get_device_files<T>(path: T) -> std::io::Result<Vec<File>>
+where
+    T: AsRef<Path>,
+{
+    let mut files = Vec::new();
+
+    for entry in read_dir(path)? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+
+        if !file_name.starts_with("event") {
+            continue;
+        }
+
+        match File::open(&path) {
+            Ok(file) => files.push(file),
+            Err(error) => eprintln!(
+                "handy-keys: skipping input device {}: {error}",
+                path.display()
+            ),
+        }
+    }
+
+    Ok(files)
+}
+
+fn handle_input_event(event: &InputEvent, state: &Arc<Mutex<ListenerState>>) {
+    let EventCode::EV_KEY(ref ev_key) = event.event_code else {
+        return;
+    };
+
+    let is_key_down = match event.value {
+        0 => false,
+        1 | 2 => true,
+        _ => return,
+    };
+
+    if let Ok(mut state) = state.lock() {
+        process_key_event(&mut state, ev_key, is_key_down);
+    }
+}
+
+fn process_key_event(state: &mut ListenerState, ev_key: &EV_KEY, is_key_down: bool) {
+    if let Some(changed_modifier) = evdev_key_to_modifier(ev_key) {
+        let previous_modifiers = state.current_modifiers;
+        state.current_modifiers = update_modifiers(state.current_modifiers, ev_key, is_key_down);
+
+        if state.current_modifiers != previous_modifiers {
+            let _ = state.event_sender.send(KeyEvent {
+                modifiers: state.current_modifiers,
+                key: None,
+                is_key_down,
+                changed_modifier: Some(changed_modifier),
+            });
+        }
+
+        return;
+    }
+
+    let Some(key) = evdev_key_to_key(ev_key) else {
+        return;
+    };
+
+    if should_ignore_common_mouse_button(key, state.current_modifiers) {
+        return;
+    }
+
+    let _ = state.event_sender.send(KeyEvent {
+        modifiers: state.current_modifiers,
+        key: Some(key),
+        is_key_down,
+        changed_modifier: None,
+    });
+}
+
+fn should_ignore_common_mouse_button(key: Key, modifiers: Modifiers) -> bool {
+    matches!(key, Key::MouseLeft | Key::MouseRight) && modifiers.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use evdev_rs::TimeVal;
+    use std::sync::mpsc::{self, Receiver};
+
+    fn state_and_receiver() -> (ListenerState, Receiver<KeyEvent>) {
+        let (tx, rx) = mpsc::channel();
+        (ListenerState::new(tx), rx)
+    }
+
+    fn recv_event(rx: &Receiver<KeyEvent>) -> KeyEvent {
+        rx.try_recv().expect("expected a key event")
+    }
+
+    fn input_event(key: EV_KEY, value: i32) -> InputEvent {
+        InputEvent::new(&TimeVal::new(0, 0), &EventCode::EV_KEY(key), value)
+    }
+
+    #[test]
+    fn modifier_events_emit_only_when_state_changes() {
+        let (mut state, rx) = state_and_receiver();
+
+        process_key_event(&mut state, &EV_KEY::KEY_LEFTSHIFT, true);
+        let event = recv_event(&rx);
+        assert_eq!(event.modifiers, Modifiers::SHIFT_LEFT);
+        assert_eq!(event.key, None);
+        assert!(event.is_key_down);
+        assert_eq!(event.changed_modifier, Some(Modifiers::SHIFT_LEFT));
+
+        process_key_event(&mut state, &EV_KEY::KEY_LEFTSHIFT, true);
+        assert!(rx.try_recv().is_err());
+
+        process_key_event(&mut state, &EV_KEY::KEY_LEFTSHIFT, false);
+        let event = recv_event(&rx);
+        assert_eq!(event.modifiers, Modifiers::empty());
+        assert_eq!(event.key, None);
+        assert!(!event.is_key_down);
+        assert_eq!(event.changed_modifier, Some(Modifiers::SHIFT_LEFT));
+    }
+
+    #[test]
+    fn repeat_events_are_key_down_events() {
+        let (tx, rx) = mpsc::channel();
+        let state = Arc::new(Mutex::new(ListenerState::new(tx)));
+
+        handle_input_event(&input_event(EV_KEY::KEY_A, 2), &state);
+
+        let event = recv_event(&rx);
+        assert_eq!(event.modifiers, Modifiers::empty());
+        assert_eq!(event.key, Some(Key::A));
+        assert!(event.is_key_down);
+        assert_eq!(event.changed_modifier, None);
+    }
+
+    #[test]
+    fn common_mouse_buttons_require_modifiers() {
+        let (mut state, rx) = state_and_receiver();
+
+        process_key_event(&mut state, &EV_KEY::BTN_LEFT, true);
+        assert!(rx.try_recv().is_err());
+
+        process_key_event(&mut state, &EV_KEY::KEY_LEFTSHIFT, true);
+        let _ = recv_event(&rx);
+
+        process_key_event(&mut state, &EV_KEY::BTN_LEFT, true);
+        let event = recv_event(&rx);
+        assert_eq!(event.modifiers, Modifiers::SHIFT_LEFT);
+        assert_eq!(event.key, Some(Key::MouseLeft));
+        assert!(event.is_key_down);
+        assert_eq!(event.changed_modifier, None);
+    }
+}

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,4 +1,21 @@
-//! Linux platform support using rdev
+//! Linux platform support.
 
+#[cfg(not(any(feature = "linux-rdev-grab", feature = "linux-evdev-readonly")))]
+compile_error!("enable either the linux-rdev-grab or linux-evdev-readonly feature");
+
+#[cfg(all(feature = "linux-rdev-grab", feature = "linux-evdev-readonly"))]
+compile_error!("linux-rdev-grab and linux-evdev-readonly are mutually exclusive");
+
+#[cfg(feature = "linux-evdev-readonly")]
+#[path = "keycode_evdev.rs"]
 pub(crate) mod keycode;
+
+#[cfg(feature = "linux-rdev-grab")]
+pub(crate) mod keycode;
+
+#[cfg(feature = "linux-evdev-readonly")]
+#[path = "listener_evdev.rs"]
+pub(crate) mod listener;
+
+#[cfg(feature = "linux-rdev-grab")]
 pub(crate) mod listener;

--- a/src/platform/state.rs
+++ b/src/platform/state.rs
@@ -4,7 +4,9 @@ use std::collections::HashSet;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
-use crate::types::{Hotkey, Key, KeyEvent, Modifiers};
+#[cfg(not(all(target_os = "linux", feature = "linux-evdev-readonly")))]
+use crate::types::Key;
+use crate::types::{Hotkey, KeyEvent, Modifiers};
 
 /// Hotkeys that should be blocked when triggered
 pub type BlockingHotkeys = Arc<Mutex<HashSet<Hotkey>>>;
@@ -15,10 +17,20 @@ pub struct ListenerState {
     /// Track which modifiers are currently held
     pub current_modifiers: Modifiers,
     /// Hotkeys to block (if any)
+    #[cfg(not(all(target_os = "linux", feature = "linux-evdev-readonly")))]
     pub blocking_hotkeys: Option<BlockingHotkeys>,
 }
 
 impl ListenerState {
+    #[cfg(all(target_os = "linux", feature = "linux-evdev-readonly"))]
+    pub fn new(event_sender: Sender<KeyEvent>) -> Self {
+        Self {
+            event_sender,
+            current_modifiers: Modifiers::empty(),
+        }
+    }
+
+    #[cfg(not(all(target_os = "linux", feature = "linux-evdev-readonly")))]
     pub fn new(event_sender: Sender<KeyEvent>, blocking_hotkeys: Option<BlockingHotkeys>) -> Self {
         Self {
             event_sender,
@@ -28,6 +40,7 @@ impl ListenerState {
     }
 
     /// Check if an event matches a blocking hotkey
+    #[cfg(not(all(target_os = "linux", feature = "linux-evdev-readonly")))]
     pub fn should_block(&self, modifiers: Modifiers, key: Option<Key>) -> bool {
         if let Some(ref hotkeys) = self.blocking_hotkeys {
             if let Ok(set) = hotkeys.lock() {


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read Handy's CONTRIBUTING.md and mirrored its PR template because handy-keys does not currently have one

**If this is a feature or change that was previously closed/rejected:**

N/A — this is not reopening a previously closed handy-keys PR.

## Human Written Description

(The fact my agent keeps insisting on writing this section for me is deeply troubling.)

This PR adds evdev as a parallel linux BE adjacent to rdev::grab. This provides Wayland compatibility, but required the user be a member of the input group. It also does not provide blocking as it is read-only. however performance and consistency is significantly better than relying only on the compositor for hotkeys.

## Related Issues/Discussions

Fixes #
Discussion: https://github.com/cjpais/Handy/discussions/604
Related Handy context: https://github.com/cjpais/Handy/discussions/604#discussioncomment-16859242

## Community Feedback

The need comes from Handy's Linux global shortcut / Wayland discussion, where evdev was discussed as a possible path for reliable global shortcut observation.

## Summary

- Add an opt-in `linux-evdev-readonly` backend that observes `/dev/input/event*` devices without grabbing or blocking input.
- Keep the existing Linux `rdev` grab backend as the default via `linux-rdev-grab`.
- Document evdev permissions, startup-only device scanning, and non-blocking behavior, including `new_with_blocking`.

## Testing

- `cargo check --lib`
- `cargo test --lib`
- `cargo check --lib --no-default-features --features linux-evdev-readonly`
- `cargo test --lib --no-default-features --features linux-evdev-readonly`
- `cargo check --example record_hotkey --no-default-features --features linux-evdev-readonly`
- `rustfmt --check --config skip_children=true src/listener.rs src/manager.rs src/platform/state.rs src/platform/linux/mod.rs src/platform/linux/keycode_evdev.rs src/platform/linux/listener_evdev.rs`
- `git diff --check`
- [x] works on my box ;)

## Screenshots/Videos (if applicable)

N/A — backend library change only.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code / OpenAI GPT-5.5 via opencode
- How extensively: AI assisted with implementation, local review, test additions, and PR description drafting. Human review guided scope and kept the diff focused.