### PR TITLE
Fix Windows mouse hotkey blocking

### DIFF
--- a/src/platform/windows/listener.rs
+++ b/src/platform/windows/listener.rs
@@ -228,6 +228,8 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
         return CallNextHookEx(None, code, wparam, lparam);
     }
 
+    let mut should_block = false;
+
     // Process the mouse event
     HOOK_CONTEXT.with(|ctx_cell| {
         let mut ctx_ref = ctx_cell.borrow_mut();
@@ -272,6 +274,9 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
             };
 
             if let Some(key) = key {
+                should_block =
+                    should_block_hotkey(&ctx.blocking_hotkeys, ctx.current_modifiers, Some(key));
+
                 let _ = ctx.event_sender.send(KeyEvent {
                     modifiers: ctx.current_modifiers,
                     key: Some(key),
@@ -282,8 +287,13 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
         }
     });
 
-    // Always pass mouse events through (no blocking for mouse)
-    CallNextHookEx(None, code, wparam, lparam)
+    if should_block {
+        // Return non-zero to block the event from propagating
+        LRESULT(1)
+    } else {
+        // Pass to next hook in chain
+        CallNextHookEx(None, code, wparam, lparam)
+    }
 }
 
 /// Check if a hotkey combination should be blocked
@@ -351,5 +361,23 @@ mod tests {
         let mut msg = MSG::default();
         assert!(drain_thread_messages(&mut msg));
         clear_message_queue();
+    }
+
+    #[test]
+    fn should_block_registered_mouse_hotkey() {
+        let mut hotkeys = std::collections::HashSet::new();
+        hotkeys.insert(Hotkey::new(Modifiers::empty(), Key::MouseX1).unwrap());
+        let blocking_hotkeys = Some(std::sync::Arc::new(std::sync::Mutex::new(hotkeys)));
+
+        assert!(should_block_hotkey(
+            &blocking_hotkeys,
+            Modifiers::empty(),
+            Some(Key::MouseX1)
+        ));
+        assert!(!should_block_hotkey(
+            &blocking_hotkeys,
+            Modifiers::empty(),
+            Some(Key::MouseX2)
+        ));
     }
 }

--- a/tests/synthetic_input.rs
+++ b/tests/synthetic_input.rs
@@ -94,8 +94,9 @@ mod macos {
 mod windows_tests {
     use super::*;
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-        KEYEVENTF_SCANCODE, VIRTUAL_KEY, VK_F20,
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
+        KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE, MOUSEINPUT, MOUSEEVENTF_MIDDLEUP, MOUSE_EVENT_FLAGS,
+        VIRTUAL_KEY, VK_F20,
     };
 
     fn send_f20(key_up: bool) {
@@ -190,6 +191,43 @@ mod windows_tests {
         assert!(
             saw_key_event(&listener, Key::Quote, false, Duration::from_secs(2)),
             "quote-position scancode 0x28 did not map to Key::Quote"
+        );
+    }
+
+    /// Inject a lone mouse-button event by flag. Mirrors the keyboard
+    /// lone-key-up trick: a button-up with no preceding button-down is still
+    /// observed by the low-level hook but performs no action in the session.
+    fn send_mouse_flag(flags: MOUSE_EVENT_FLAGS, mouse_data: u32) {
+        let input = INPUT {
+            r#type: INPUT_MOUSE,
+            Anonymous: INPUT_0 {
+                mi: MOUSEINPUT {
+                    dx: 0,
+                    dy: 0,
+                    mouseData: mouse_data,
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let sent = unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32) };
+        assert_eq!(sent, 1, "SendInput failed");
+    }
+
+    /// The mouse hook path reports button transitions end-to-end. Middle and
+    /// X buttons are reported unconditionally (left/right are gated on a held
+    /// modifier), so a lone middle-button-up is the disturbance-free probe.
+    #[test]
+    #[ignore = "needs an interactive desktop session; run: cargo test --test synthetic_input -- --ignored"]
+    fn injected_mouse_button_reaches_listener() {
+        let listener = KeyboardListener::new().expect("failed to spawn keyboard listener");
+        std::thread::sleep(Duration::from_millis(200));
+
+        send_mouse_flag(MOUSEEVENTF_MIDDLEUP, 0);
+        assert!(
+            saw_key_event(&listener, Key::MouseMiddle, false, Duration::from_secs(2)),
+            "did not observe injected middle-button-up as Key::MouseMiddle"
         );
     }
 }


### PR DESCRIPTION
## Summary

Windows mouse hotkeys now respect `new_with_blocking()` the same way keyboard hotkeys already do 😎👍 The hook was detecting side buttons just fine, but then it always forwarded the mouse event onward, so `MouseX1` could trigger a registered shortcut and still hit browser Back in the foreground app.

- 🐛 Block matching mouse hotkeys when they are present in `blocking_hotkeys`
- 🖱️ Keep non-matching mouse events passing through exactly like before
- ✅ Add a focused unit check so `MouseX1` matches while `MouseX2` stays untouched

## Why This Matters

`HotkeyManager::new_with_blocking()` already advertises that registered hotkeys are blocked from reaching other applications 🚧 Keyboard events followed that contract on Windows, but mouse buttons were leaking through. This makes the Windows mouse path line up with the documented blocking behavior without changing `HotkeyManager::new()` for listen-only callers.

Requirement for https://github.com/cjpais/Handy/pull/1524
