### PR TITLE
Fix modifier-only hotkey release logic + local test scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ path = "examples/basic.rs"
 name = "record_hotkey"
 path = "examples/record_hotkey.rs"
 
+[[example]]
+name = "diagnostic"
+path = "examples/diagnostic.rs"
+
 [dependencies]
 bitflags = { version = "2", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
@@ -43,3 +47,10 @@ windows = { version = "0.58", features = [
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rdev = { version = "0.5.3", features = ["unstable_grab"] }
+
+# Synthetic input injection for the integration tests (tests/synthetic_input.rs)
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_UI_Input_KeyboardAndMouse",
+] }

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,9 +1,6 @@
 # Testing
 
-There is no CI; every PR is verified locally before merge. Testing has
-three layers — run the ones that match what your change touches.
-
-## 1. Unit tests — any machine
+## 1. Unit tests
 
 ```sh
 cargo test
@@ -13,7 +10,7 @@ Covers the platform-independent logic: hotkey matching, modifier
 semantics, string parsing, and the manager's press/release state machine.
 Always run this; it must stay green on every commit.
 
-## 2. Cross-target check — any machine
+## 2. Cross-target check
 
 ```sh
 ./scripts/check-all.sh
@@ -70,11 +67,3 @@ carry Fn on this keyboard?", "what does this layout report for the key
 next to 1?") and ask bug reporters to paste its output. A key that
 produces *no* output is itself a finding — it means the platform backend
 cannot map it.
-
-## Pre-merge checklist
-
-1. `cargo test` — green.
-2. `./scripts/check-all.sh` — green.
-3. If the change touches a platform backend: run layer 3 on that machine,
-   plus any scenario checks the PR calls out (e.g. lock/unlock cycles for
-   Windows session handling).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,80 @@
+# Testing
+
+There is no CI; every PR is verified locally before merge. Testing has
+three layers — run the ones that match what your change touches.
+
+## 1. Unit tests — any machine
+
+```sh
+cargo test
+```
+
+Covers the platform-independent logic: hotkey matching, modifier
+semantics, string parsing, and the manager's press/release state machine.
+Always run this; it must stay green on every commit.
+
+## 2. Cross-target check — any machine
+
+```sh
+./scripts/check-all.sh
+```
+
+Runs the unit tests on the host, then `cargo check --all-targets` for the
+other supported platforms so platform-specific compile breakage is caught
+without sitting at that machine. Needs the target stdlibs once:
+
+```sh
+rustup target add x86_64-pc-windows-msvc    # from macOS/Linux
+rustup target add aarch64-apple-darwin      # from other hosts
+```
+
+Known limitation: the Linux target cannot be cross-checked because rdev's
+`evdev-sys` dependency builds C libevdev via autotools. Until the rdev
+backend is replaced with a pure-Rust evdev implementation, Linux compile
+errors only surface when building on a Linux machine (which additionally
+needs autotools installed for that same dependency).
+
+## 3. Integration tests — on the target machine
+
+```sh
+cargo test --test synthetic_input -- --ignored
+```
+
+Drives the real platform backend end-to-end by injecting synthetic input
+through the OS and asserting on the events the listener emits. `#[ignore]`d
+by default because they need a real interactive session.
+
+- **macOS**: requires accessibility permission for the terminal running
+  the tests (System Settings > Privacy & Security > Accessibility).
+  Injection uses `CGEventPost`.
+- **Windows**: requires an interactive desktop session. Injection uses
+  `SendInput`.
+- **Linux**: no harness yet — the rdev backend exclusively grabs real
+  input devices, which is unsafe to drive from a test. A uinput-based
+  harness (virtual keyboard, indistinguishable from hardware at the evdev
+  layer) lands with the in-tree evdev backend.
+
+The tests inject **F20** only: it exists in the `Key` enum everywhere and
+does nothing in terminals or desktop environments, so a test run never
+types into the session it runs in.
+
+## Manual characterization — `diagnostic` example
+
+```sh
+cargo run --example diagnostic
+```
+
+Dumps every event the listener emits (timestamps, key, modifiers, raw
+modifier bits). Use it for hardware characterization sessions ("does F13
+carry Fn on this keyboard?", "what does this layout report for the key
+next to 1?") and ask bug reporters to paste its output. A key that
+produces *no* output is itself a finding — it means the platform backend
+cannot map it.
+
+## Pre-merge checklist
+
+1. `cargo test` — green.
+2. `./scripts/check-all.sh` — green.
+3. If the change touches a platform backend: run layer 3 on that machine,
+   plus any scenario checks the PR calls out (e.g. lock/unlock cycles for
+   Windows session handling).

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,4 @@
-use handy_keys::{
-    check_accessibility, open_accessibility_settings, Hotkey, HotkeyManager, HotkeyState, Key,
-    Modifiers, Result,
-};
+use handy_keys::{Hotkey, HotkeyManager, HotkeyState, Key, Modifiers, Result};
 use std::io::Write;
 
 fn log(msg: &str) {
@@ -19,18 +16,23 @@ fn log(msg: &str) {
 
 fn main() -> Result<()> {
     log("=== Starting keyboard test ===");
-    // Check accessibility permission
-    let has_access = check_accessibility();
-    log(&format!("Accessibility permission check: {}", has_access));
+    // Check accessibility permission (macOS only)
+    #[cfg(target_os = "macos")]
+    {
+        use handy_keys::{check_accessibility, open_accessibility_settings};
 
-    if !has_access {
-        log("Accessibility permission not granted!");
-        log("Opening System Settings...");
-        if let Err(e) = open_accessibility_settings() {
-            log(&format!("Failed to open settings: {}", e));
+        let has_access = check_accessibility();
+        log(&format!("Accessibility permission check: {}", has_access));
+
+        if !has_access {
+            log("Accessibility permission not granted!");
+            log("Opening System Settings...");
+            if let Err(e) = open_accessibility_settings() {
+                log(&format!("Failed to open settings: {}", e));
+            }
+            log("Please grant permission and restart.");
+            std::process::exit(1);
         }
-        log("Please grant permission and restart.");
-        std::process::exit(1);
     }
 
     log("Creating hotkey manager...");

--- a/examples/diagnostic.rs
+++ b/examples/diagnostic.rs
@@ -1,0 +1,64 @@
+//! Diagnostic event dump for hardware characterization and bug reports.
+//!
+//! Prints every event the `KeyboardListener` emits, with millisecond
+//! timestamps and raw modifier bits. Use this to answer questions like
+//! "does F13 carry the Fn modifier on this keyboard?" or "what does this
+//! layout report for the key next to 1?" — and paste the output into
+//! bug reports.
+//!
+//! Run with: cargo run --example diagnostic
+//! Exit with Ctrl+C.
+//!
+//! Notes:
+//! - Keys the platform backend cannot map are invisible here (no event is
+//!   emitted for them). If a key produces no output, that itself is a
+//!   finding — note it.
+//! - macOS requires accessibility permission for the terminal running this.
+//! - Left/right mouse buttons are only reported while a modifier is held
+//!   (by design, to avoid noise).
+
+use std::time::Instant;
+
+use handy_keys::KeyboardListener;
+
+fn main() -> handy_keys::Result<()> {
+    println!(
+        "handy-keys {} diagnostic — os={} arch={}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    );
+    println!("Press keys to dump events. Ctrl+C to exit.");
+    println!();
+
+    let listener = KeyboardListener::new()?;
+    let start = Instant::now();
+
+    while let Ok(event) = listener.recv() {
+        let state = if event.is_key_down { "DOWN" } else { "UP  " };
+        let mods = if event.modifiers.is_empty() {
+            "(none)".to_string()
+        } else {
+            event.modifiers.to_string()
+        };
+        let changed = match event.changed_modifier {
+            Some(m) => format!(" changed={}", m),
+            None => String::new(),
+        };
+
+        println!(
+            "[+{:>8}ms] {} key={:<16} mods={} (bits=0x{:03x}){}",
+            start.elapsed().as_millis(),
+            state,
+            event
+                .key
+                .map(|k| format!("{:?}", k))
+                .unwrap_or_else(|| "-".to_string()),
+            mods,
+            event.modifiers.bits(),
+            changed,
+        );
+    }
+
+    Ok(())
+}

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Local substitute for a CI matrix: run the unit tests on the host, then
+# type-check the code (including tests and examples) for the other
+# supported platforms so platform-specific compile breakage is caught
+# without sitting at that machine.
+#
+# Cross-target checks need the target's stdlib installed once:
+#   rustup target add x86_64-pc-windows-msvc x86_64-unknown-linux-gnu
+#
+# See TESTING.md for the full pre-merge checklist.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+host_triple=$(rustc -vV | sed -n 's/^host: //p')
+
+echo "==> cargo test ($host_triple)"
+cargo test --quiet
+
+# x86_64-unknown-linux-gnu is intentionally absent: rdev pulls in
+# evdev-sys, which builds C libevdev via autotools and cannot be
+# cross-checked. Re-add it when the in-tree evdev backend (pure Rust)
+# replaces rdev.
+targets=(
+    x86_64-pc-windows-msvc
+    aarch64-apple-darwin
+)
+installed=$(rustup target list --installed)
+
+for target in "${targets[@]}"; do
+    if [[ "$target" == "$host_triple" ]]; then
+        continue
+    fi
+    if ! grep -qx "$target" <<<"$installed"; then
+        echo "==> SKIP $target (install with: rustup target add $target)"
+        continue
+    fi
+    echo "==> cargo check --target $target --all-targets"
+    cargo check --quiet --target "$target" --all-targets
+done
+
+echo "==> all checks passed"

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -52,13 +52,17 @@ impl ManagerState {
             }
         } else {
             // Check for hotkeys that should be released
-            // A hotkey is released when either its key is released or its modifiers change
+            // A hotkey is released when its key is released, or — for modifier
+            // events — when the modifiers no longer match. A modifier event
+            // (key == None) whose modifiers still match must not release a
+            // modifier-only hotkey (e.g. tapping Shift while a Cmd-only hotkey
+            // is held).
             let to_release: Vec<HotkeyId> = self
                 .hotkeys
                 .iter()
                 .filter(|(&id, hotkey)| {
                     self.pressed_hotkeys.contains(&id)
-                        && (hotkey.key == event.key
+                        && ((event.key.is_some() && hotkey.key == event.key)
                             || (event.key.is_none() && !hotkey.modifiers.matches(event.modifiers)))
                 })
                 .map(|(&id, _)| id)
@@ -486,6 +490,101 @@ mod tests {
             let results = state.process_event(&event);
 
             assert_eq!(results.len(), 0);
+        }
+
+        #[test]
+        fn modifier_only_hotkey_not_released_by_unrelated_modifier() {
+            let mut state = ManagerState::new();
+            let hotkey = Hotkey::new(Modifiers::CMD, None).unwrap();
+            let id = HotkeyId(0);
+            state.hotkeys.insert(id, hotkey);
+
+            // Cmd down — hotkey pressed
+            let event = make_modifier_event(Modifiers::CMD_LEFT, true, Modifiers::CMD_LEFT);
+            let results = state.process_event(&event);
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].state, HotkeyState::Pressed);
+
+            // Shift down while Cmd held — no state change
+            let event = make_modifier_event(
+                Modifiers::CMD_LEFT | Modifiers::SHIFT_LEFT,
+                true,
+                Modifiers::SHIFT_LEFT,
+            );
+            assert_eq!(state.process_event(&event).len(), 0);
+
+            // Shift up — Cmd is still held and still matches, so the hotkey
+            // must NOT be released
+            let event = make_modifier_event(Modifiers::CMD_LEFT, false, Modifiers::SHIFT_LEFT);
+            assert_eq!(state.process_event(&event).len(), 0);
+            assert!(state.pressed_hotkeys.contains(&id));
+
+            // Cmd up — now it releases
+            let event = make_modifier_event(Modifiers::empty(), false, Modifiers::CMD_LEFT);
+            let results = state.process_event(&event);
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].state, HotkeyState::Released);
+            assert!(!state.pressed_hotkeys.contains(&id));
+        }
+
+        #[test]
+        fn modifier_only_hotkey_releases_on_own_modifier_release() {
+            let mut state = ManagerState::new();
+            let hotkey = Hotkey::new(Modifiers::CMD, None).unwrap();
+            let id = HotkeyId(0);
+            state.hotkeys.insert(id, hotkey);
+
+            let event = make_modifier_event(Modifiers::CMD_LEFT, true, Modifiers::CMD_LEFT);
+            state.process_event(&event);
+            assert!(state.pressed_hotkeys.contains(&id));
+
+            let event = make_modifier_event(Modifiers::empty(), false, Modifiers::CMD_LEFT);
+            let results = state.process_event(&event);
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].state, HotkeyState::Released);
+        }
+
+        #[test]
+        fn compound_modifier_only_hotkey_releases_on_partial_release() {
+            let mut state = ManagerState::new();
+            let hotkey = Hotkey::new(Modifiers::CMD | Modifiers::SHIFT, None).unwrap();
+            let id = HotkeyId(0);
+            state.hotkeys.insert(id, hotkey);
+
+            // Cmd down, then Shift down — pressed once both are held
+            let event = make_modifier_event(Modifiers::CMD_LEFT, true, Modifiers::CMD_LEFT);
+            assert_eq!(state.process_event(&event).len(), 0);
+            let event = make_modifier_event(
+                Modifiers::CMD_LEFT | Modifiers::SHIFT_LEFT,
+                true,
+                Modifiers::SHIFT_LEFT,
+            );
+            let results = state.process_event(&event);
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].state, HotkeyState::Pressed);
+
+            // Releasing either modifier breaks the match — released
+            let event = make_modifier_event(Modifiers::SHIFT_LEFT, false, Modifiers::CMD_LEFT);
+            let results = state.process_event(&event);
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].state, HotkeyState::Released);
+        }
+
+        #[test]
+        fn keyed_hotkey_not_released_by_unrelated_key_release() {
+            let mut state = ManagerState::new();
+            let hotkey = Hotkey::new(Modifiers::CMD, Key::K).unwrap();
+            let id = HotkeyId(0);
+            state.hotkeys.insert(id, hotkey);
+
+            let event = make_key_event(Modifiers::CMD_LEFT, Some(Key::K), true);
+            state.process_event(&event);
+            assert!(state.pressed_hotkeys.contains(&id));
+
+            // Release of a different key while Cmd+K is held — no release
+            let event = make_key_event(Modifiers::CMD_LEFT, Some(Key::J), false);
+            assert_eq!(state.process_event(&event).len(), 0);
+            assert!(state.pressed_hotkeys.contains(&id));
         }
 
         #[test]

--- a/src/platform/state.rs
+++ b/src/platform/state.rs
@@ -1,15 +1,22 @@
 //! Shared state for platform-specific keyboard listeners
 
 use std::collections::HashSet;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
-use crate::types::{Hotkey, Key, KeyEvent, Modifiers};
+use crate::types::Hotkey;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use crate::types::{Key, KeyEvent, Modifiers};
 
 /// Hotkeys that should be blocked when triggered
 pub type BlockingHotkeys = Arc<Mutex<HashSet<Hotkey>>>;
 
 /// Internal state shared with platform-specific event callbacks
+///
+/// Used by the macOS and Linux backends; the Windows backend keeps its
+/// state in a thread-local `HookContext` instead.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub struct ListenerState {
     pub event_sender: Sender<KeyEvent>,
     /// Track which modifiers are currently held
@@ -18,6 +25,7 @@ pub struct ListenerState {
     pub blocking_hotkeys: Option<BlockingHotkeys>,
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl ListenerState {
     pub fn new(event_sender: Sender<KeyEvent>, blocking_hotkeys: Option<BlockingHotkeys>) -> Self {
         Self {

--- a/src/platform/windows/listener.rs
+++ b/src/platform/windows/listener.rs
@@ -2,21 +2,21 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, DispatchMessageW, MsgWaitForMultipleObjects, PeekMessageW, SetWindowsHookExW,
     TranslateMessage, UnhookWindowsHookEx, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, MSG, MSLLHOOKSTRUCT,
-    PM_REMOVE, QS_ALLINPUT, WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN,
+    PM_REMOVE, QS_ALLINPUT, WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_LBUTTONDOWN,
     WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP,
-    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_XBUTTONDOWN, WM_XBUTTONUP,
+    WM_SYSKEYDOWN, WM_XBUTTONDOWN, WM_XBUTTONUP,
 };
 
 use crate::error::Result;
 use crate::platform::state::BlockingHotkeys;
-use crate::types::{Hotkey, Key, KeyEvent, Modifiers};
+use crate::types::{Key, KeyEvent, Modifiers};
 
 use super::keycode::{vk_to_key, vk_to_modifier};
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -2,5 +2,3 @@
 
 mod keycode;
 pub(crate) mod listener;
-
-pub(crate) use keycode::{vk_to_key, vk_to_modifier};

--- a/tests/synthetic_input.rs
+++ b/tests/synthetic_input.rs
@@ -1,0 +1,140 @@
+//! Platform integration tests driven by synthetic input injection.
+//!
+//! These tests exercise the real platform backend end-to-end: they spawn a
+//! `KeyboardListener`, inject input through the OS (`CGEventPost` on macOS,
+//! `SendInput` on Windows), and assert on what comes out of the event
+//! channel.
+//!
+//! They are `#[ignore]`d because they need a real interactive session (and
+//! on macOS, accessibility permission for the process running the tests).
+//! Run them on the target machine as part of the pre-merge checklist:
+//!
+//! ```sh
+//! cargo test --test synthetic_input -- --ignored
+//! ```
+//!
+//! Linux is intentionally absent: the current rdev backend requires an X11
+//! display and exclusively grabs real input devices, which makes it unsafe
+//! to drive from a test. A uinput-based harness (virtual keyboard device,
+//! indistinguishable from hardware at the evdev layer) lands together with
+//! the in-tree evdev backend that replaces rdev.
+//!
+//! All injections use F20: it exists in the `Key` enum on both platforms
+//! and does nothing in terminals or the desktop environment, so a test run
+//! never types into or otherwise disturbs the session it runs in.
+
+#![cfg(any(target_os = "macos", target_os = "windows"))]
+
+use std::time::{Duration, Instant};
+
+use handy_keys::{Key, KeyboardListener};
+
+/// Drain listener events until we see `key` in the given direction, or
+/// time out. Other events (e.g. real user input during the run) are
+/// skipped rather than failing the test.
+fn saw_key_event(
+    listener: &KeyboardListener,
+    key: Key,
+    is_key_down: bool,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        match listener.recv_timeout(remaining) {
+            Ok(event) => {
+                if event.key == Some(key) && event.is_key_down == is_key_down {
+                    return true;
+                }
+            }
+            Err(_) => return false,
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use objc2_core_graphics::{CGEvent, CGEventSource, CGEventSourceStateID, CGEventTapLocation};
+
+    const VK_F20: u16 = 0x5A;
+
+    fn post_f20(key_down: bool) {
+        let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState);
+        let event = CGEvent::new_keyboard_event(source.as_deref(), VK_F20, key_down)
+            .expect("failed to create keyboard event");
+        CGEvent::post(CGEventTapLocation::HIDEventTap, Some(&event));
+    }
+
+    #[test]
+    #[ignore = "needs accessibility permission; run: cargo test --test synthetic_input -- --ignored"]
+    fn injected_f20_reaches_listener() {
+        let listener = KeyboardListener::new().expect(
+            "KeyboardListener::new failed — grant accessibility permission to the \
+             terminal running this test (System Settings > Privacy & Security > Accessibility)",
+        );
+
+        post_f20(true);
+        assert!(
+            saw_key_event(&listener, Key::F20, true, Duration::from_secs(2)),
+            "did not observe injected F20 key-down"
+        );
+
+        post_f20(false);
+        assert!(
+            saw_key_event(&listener, Key::F20, false, Duration::from_secs(2)),
+            "did not observe injected F20 key-up"
+        );
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_tests {
+    use super::*;
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+        VK_F20,
+    };
+
+    fn send_f20(key_up: bool) {
+        let input = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VK_F20,
+                    wScan: 0,
+                    dwFlags: if key_up {
+                        KEYEVENTF_KEYUP
+                    } else {
+                        KEYBD_EVENT_FLAGS(0)
+                    },
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let sent = unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32) };
+        assert_eq!(sent, 1, "SendInput failed");
+    }
+
+    #[test]
+    #[ignore = "needs an interactive desktop session; run: cargo test --test synthetic_input -- --ignored"]
+    fn injected_f20_reaches_listener() {
+        let listener = KeyboardListener::new().expect("failed to spawn keyboard listener");
+        // Give the hook thread a moment to install the hooks; spawn() does
+        // not currently wait for installation (known gap, see review notes).
+        std::thread::sleep(Duration::from_millis(200));
+
+        send_f20(false);
+        assert!(
+            saw_key_event(&listener, Key::F20, true, Duration::from_secs(2)),
+            "did not observe injected F20 key-down"
+        );
+
+        send_f20(true);
+        assert!(
+            saw_key_event(&listener, Key::F20, false, Duration::from_secs(2)),
+            "did not observe injected F20 key-up"
+        );
+    }
+}


### PR DESCRIPTION
* Manager fix: modifier-only hotkeys no longer get spuriously released when an unrelated modifier is tapped.
* Add test scaffolding
* Compilation fixes