### PR TITLE
map punctuation keys by scancode, drop altgr phantom ctl, add f21-f24

### DIFF
--- a/src/platform/windows/keycode.rs
+++ b/src/platform/windows/keycode.rs
@@ -77,6 +77,10 @@ mod vk {
     pub const F18: u16 = 0x81;
     pub const F19: u16 = 0x82;
     pub const F20: u16 = 0x83;
+    pub const F21: u16 = 0x84;
+    pub const F22: u16 = 0x85;
+    pub const F23: u16 = 0x86;
+    pub const F24: u16 = 0x87;
 
     // Left/Right modifier variants
     pub const LSHIFT: u16 = 0xA0;
@@ -102,10 +106,122 @@ mod vk {
     pub const OEM_102: u16 = 0xE2; // ISO extra key (between Left Shift and Z)
 }
 
-/// Convert Windows virtual key code to Key
+/// Scan Code Set 1 make codes for the punctuation key positions.
+///
+/// Scancodes identify the physical key position and never move with the
+/// active layout, matching macOS virtual keycodes and evdev codes (both
+/// positional). Names follow the US-layout legend for each position.
+#[allow(dead_code)]
+mod sc {
+    pub const GRAVE: u32 = 0x29; // left of 1 (US `~, UK `¬)
+    pub const MINUS: u32 = 0x0C;
+    pub const EQUAL: u32 = 0x0D;
+    pub const LEFT_BRACKET: u32 = 0x1A;
+    pub const RIGHT_BRACKET: u32 = 0x1B;
+    pub const BACKSLASH: u32 = 0x2B; // ANSI \| above Enter; ISO #~ next to Enter
+    pub const SEMICOLON: u32 = 0x27;
+    pub const QUOTE: u32 = 0x28; // right of ; (US '", UK '@)
+    pub const COMMA: u32 = 0x33;
+    pub const PERIOD: u32 = 0x34;
+    pub const SLASH: u32 = 0x35;
+    pub const ISO_SECTION: u32 = 0x56; // ISO extra key between Left Shift and Z
+    pub const LCONTROL: u32 = 0x1D;
+}
+
+/// Scancode of the phantom Left Ctrl that Windows synthesizes around every
+/// Right Alt press/release on AltGr layouts: LCtrl's make code (0x1D) with
+/// bit 9 set. Captured live on UK layout — the pair arrives with identical
+/// timestamps. Real Left Ctrl presses carry plain 0x1D.
+pub const ALTGR_PHANTOM_CTRL_SCANCODE: u32 = 0x21D;
+
+/// True for the synthetic Left Ctrl event injected by AltGr handling.
+/// These carry no user intent — the user pressed only Right Alt — so the
+/// listener drops them entirely.
+pub fn is_altgr_phantom_ctrl(vk_code: u16, scan_code: u32) -> bool {
+    vk_code == vk::LCONTROL && scan_code == ALTGR_PHANTOM_CTRL_SCANCODE
+}
+
+/// True for the VKs Windows assigns to layout-dependent punctuation keys.
+fn is_punctuation_vk(vk_code: u16) -> bool {
+    matches!(
+        vk_code,
+        vk::OEM_1
+            | vk::OEM_PLUS
+            | vk::OEM_COMMA
+            | vk::OEM_MINUS
+            | vk::OEM_PERIOD
+            | vk::OEM_2
+            | vk::OEM_3
+            | vk::OEM_4
+            | vk::OEM_5
+            | vk::OEM_6
+            | vk::OEM_7
+            | vk::OEM_8
+            | vk::OEM_102
+    )
+}
+
+/// Map a punctuation key position (Scan Code Set 1, non-extended) to a Key.
+fn punctuation_scancode_to_key(scan_code: u32) -> Option<Key> {
+    match scan_code {
+        sc::GRAVE => Some(Key::Grave),
+        sc::MINUS => Some(Key::Minus),
+        sc::EQUAL => Some(Key::Equal),
+        sc::LEFT_BRACKET => Some(Key::LeftBracket),
+        sc::RIGHT_BRACKET => Some(Key::RightBracket),
+        // The ISO #~ key (next to Enter on UK boards) shares scancode 0x2B
+        // with the ANSI \| key — they are the same logical position (macOS
+        // likewise reports both as kVK_ANSI_Backslash), so both map to
+        // Backslash.
+        sc::BACKSLASH => Some(Key::Backslash),
+        sc::SEMICOLON => Some(Key::Semicolon),
+        sc::QUOTE => Some(Key::Quote),
+        sc::COMMA => Some(Key::Comma),
+        sc::PERIOD => Some(Key::Period),
+        sc::SLASH => Some(Key::Slash),
+        sc::ISO_SECTION => Some(Key::Section),
+        _ => None,
+    }
+}
+
+/// Map a Windows keyboard event to a Key.
+///
+/// Punctuation keys are mapped from their scancode (physical position):
+/// their virtual keycodes (VK_OEM_*) move with the active layout, so e.g.
+/// on UK both the `¬ key (VK_OEM_8) and the '@ key (VK_OEM_3) would report
+/// Grave under a VK mapping, and Quote would be unreachable from the
+/// apostrophe key. Positional mapping matches what macOS virtual keycodes
+/// and evdev codes already give the other backends.
+///
+/// Everything else — letters, digits, F-keys, nav, numpad — stays on the VK
+/// mapping: those VKs are stable across layouts, and moving letters to
+/// positional mapping (e.g. AZERTY physical-Q reporting A) is a bigger
+/// behavioral decision deliberately deferred.
+///
+/// The scancode path is gated on the VK being an OEM punctuation key so a
+/// layout that places a letter on one of these positions (e.g. AZERTY M on
+/// the semicolon position) keeps reporting the letter.
+pub fn map_key(vk_code: u16, scan_code: u32, is_extended: bool) -> Option<Key> {
+    // Extended scancodes are a separate namespace (e.g. E0 35 is numpad
+    // divide, not the slash position), so only non-extended events take the
+    // positional path.
+    if !is_extended && is_punctuation_vk(vk_code) {
+        if let Some(key) = punctuation_scancode_to_key(scan_code) {
+            return Some(key);
+        }
+        // OEM VK on a position we don't know (layout put punctuation on an
+        // unusual key): fall back to the VK mapping as a best effort.
+    }
+    vk_to_key(vk_code, is_extended)
+}
+
+/// Convert Windows virtual key code to Key.
 ///
 /// The `is_extended` flag distinguishes keys like numpad Enter from main Enter.
-pub fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
+///
+/// Punctuation arms here are the US-layout interpretation, reached only as
+/// `map_key`'s fallback when the scancode position is unknown.
+fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
     match vk_code {
         // Letters A-Z (0x41-0x5A)
         0x41 => Some(Key::A),
@@ -189,6 +305,10 @@ pub fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
         vk::F18 => Some(Key::F18),
         vk::F19 => Some(Key::F19),
         vk::F20 => Some(Key::F20),
+        vk::F21 => Some(Key::F21),
+        vk::F22 => Some(Key::F22),
+        vk::F23 => Some(Key::F23),
+        vk::F24 => Some(Key::F24),
 
         // Special keys
         vk::BACK => Some(Key::Delete), // Backspace
@@ -206,7 +326,8 @@ pub fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
         vk::RIGHT => Some(Key::RightArrow),
         vk::DOWN => Some(Key::DownArrow),
 
-        // Punctuation (OEM keys - US layout)
+        // Punctuation (OEM keys - US layout interpretation; normally
+        // superseded by the positional mapping in `map_key`)
         vk::OEM_1 => Some(Key::Semicolon),
         vk::OEM_PLUS => Some(Key::Equal),
         vk::OEM_COMMA => Some(Key::Comma),
@@ -218,7 +339,7 @@ pub fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
         vk::OEM_5 => Some(Key::Backslash),
         vk::OEM_6 => Some(Key::RightBracket),
         vk::OEM_7 => Some(Key::Quote),
-        vk::OEM_8 => Some(Key::Grave),    // backtick on UK layout
+        vk::OEM_8 => Some(Key::Grave),
         vk::OEM_102 => Some(Key::Section), // ISO extra key
 
         // Lock keys
@@ -231,6 +352,9 @@ pub fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
 }
 
 /// Convert Windows virtual key code to side-specific Modifier
+///
+/// AltGr phantom Ctrl events must be filtered with `is_altgr_phantom_ctrl`
+/// before this is consulted; by VK alone they look like real Left Ctrl.
 pub fn vk_to_modifier(vk_code: u16) -> Option<Modifiers> {
     match vk_code {
         vk::LSHIFT => Some(Modifiers::SHIFT_LEFT),
@@ -245,5 +369,125 @@ pub fn vk_to_modifier(vk_code: u16) -> Option<Modifiers> {
         vk::LWIN => Some(Modifiers::CMD_LEFT),
         vk::RWIN => Some(Modifiers::CMD_RIGHT),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Punctuation keys map by physical position, whatever OEM VK the active
+    // layout assigns them. VK/scancode pairs below are as captured live
+    // (diagnostic-session-2026-07-06.md) or per the US/UK layout tables.
+
+    #[test]
+    fn grave_position_maps_to_grave_on_us_and_uk() {
+        // US `~ key: VK_OEM_3. UK `¬ key: VK_OEM_8. Same position.
+        assert_eq!(map_key(vk::OEM_3, sc::GRAVE, false), Some(Key::Grave));
+        assert_eq!(map_key(vk::OEM_8, sc::GRAVE, false), Some(Key::Grave));
+    }
+
+    #[test]
+    fn quote_position_maps_to_quote_on_us_and_uk() {
+        // US '" key: VK_OEM_7. UK '@ key: VK_OEM_3 — the VK that made both
+        // UK keys report Grave before positional mapping (cjpais/Handy#1516).
+        assert_eq!(map_key(vk::OEM_7, sc::QUOTE, false), Some(Key::Quote));
+        assert_eq!(map_key(vk::OEM_3, sc::QUOTE, false), Some(Key::Quote));
+    }
+
+    #[test]
+    fn iso_hash_key_maps_to_backslash() {
+        // UK #~ key (VK_OEM_7, next to Enter) shares position 0x2B with the
+        // ANSI \| key.
+        assert_eq!(
+            map_key(vk::OEM_7, sc::BACKSLASH, false),
+            Some(Key::Backslash)
+        );
+        assert_eq!(
+            map_key(vk::OEM_5, sc::BACKSLASH, false),
+            Some(Key::Backslash)
+        );
+    }
+
+    #[test]
+    fn remaining_punctuation_positions_map_positionally() {
+        assert_eq!(map_key(vk::OEM_MINUS, sc::MINUS, false), Some(Key::Minus));
+        assert_eq!(map_key(vk::OEM_PLUS, sc::EQUAL, false), Some(Key::Equal));
+        assert_eq!(
+            map_key(vk::OEM_4, sc::LEFT_BRACKET, false),
+            Some(Key::LeftBracket)
+        );
+        assert_eq!(
+            map_key(vk::OEM_6, sc::RIGHT_BRACKET, false),
+            Some(Key::RightBracket)
+        );
+        assert_eq!(
+            map_key(vk::OEM_1, sc::SEMICOLON, false),
+            Some(Key::Semicolon)
+        );
+        assert_eq!(map_key(vk::OEM_COMMA, sc::COMMA, false), Some(Key::Comma));
+        assert_eq!(
+            map_key(vk::OEM_PERIOD, sc::PERIOD, false),
+            Some(Key::Period)
+        );
+        assert_eq!(map_key(vk::OEM_2, sc::SLASH, false), Some(Key::Slash));
+        assert_eq!(
+            map_key(vk::OEM_102, sc::ISO_SECTION, false),
+            Some(Key::Section)
+        );
+    }
+
+    #[test]
+    fn letters_stay_on_vk_mapping_even_on_punctuation_positions() {
+        // AZERTY puts M on the semicolon position: it must stay M.
+        assert_eq!(map_key(0x4D, sc::SEMICOLON, false), Some(Key::M));
+        // German QWERTZ puts Z on the US Y position; letter VKs win.
+        assert_eq!(map_key(0x5A, 0x15, false), Some(Key::Z));
+    }
+
+    #[test]
+    fn oem_vk_on_unknown_position_falls_back_to_vk_mapping() {
+        // A layout placing punctuation on a position outside the table (e.g.
+        // Hungarian ö on the 0 key, scancode 0x0B) uses the US VK reading.
+        assert_eq!(map_key(vk::OEM_1, 0x0B, false), Some(Key::Semicolon));
+    }
+
+    #[test]
+    fn extended_events_skip_the_positional_table() {
+        // E0-prefixed scancodes are a different namespace; an extended event
+        // must not be misread as a punctuation position.
+        assert_eq!(map_key(vk::OEM_2, sc::SLASH, true), Some(Key::Slash));
+        // Numpad divide (VK_DIVIDE, E0 35) is not an OEM VK at all.
+        assert_eq!(
+            map_key(vk::DIVIDE, sc::SLASH, true),
+            Some(Key::KeypadDivide)
+        );
+    }
+
+    #[test]
+    fn f21_to_f24_map() {
+        assert_eq!(map_key(vk::F21, 0, false), Some(Key::F21));
+        assert_eq!(map_key(vk::F22, 0, false), Some(Key::F22));
+        assert_eq!(map_key(vk::F23, 0, false), Some(Key::F23));
+        assert_eq!(map_key(vk::F24, 0, false), Some(Key::F24));
+    }
+
+    #[test]
+    fn altgr_phantom_ctrl_is_detected() {
+        assert!(is_altgr_phantom_ctrl(
+            vk::LCONTROL,
+            ALTGR_PHANTOM_CTRL_SCANCODE
+        ));
+    }
+
+    #[test]
+    fn real_ctrl_events_are_not_phantom() {
+        // Real Left Ctrl: plain make code, no bit 9.
+        assert!(!is_altgr_phantom_ctrl(vk::LCONTROL, sc::LCONTROL));
+        // Right Ctrl never participates in AltGr synthesis.
+        assert!(!is_altgr_phantom_ctrl(
+            vk::RCONTROL,
+            ALTGR_PHANTOM_CTRL_SCANCODE
+        ));
     }
 }

--- a/src/platform/windows/listener.rs
+++ b/src/platform/windows/listener.rs
@@ -17,18 +17,17 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW,
     MsgWaitForMultipleObjects, PeekMessageW, RegisterClassW, SetWindowsHookExW, TranslateMessage,
-    UnhookWindowsHookEx, HHOOK, HWND_MESSAGE, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, MSG,
-    MSLLHOOKSTRUCT, PM_REMOVE, QS_ALLINPUT, WH_KEYBOARD_LL, WH_MOUSE_LL, WINDOW_EX_STYLE,
-    WINDOW_STYLE, WM_KEYDOWN, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP,
-    WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_XBUTTONDOWN, WM_XBUTTONUP,
-    WNDCLASSW,
+    UnhookWindowsHookEx, HHOOK, HWND_MESSAGE, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, MSG, MSLLHOOKSTRUCT,
+    PM_REMOVE, QS_ALLINPUT, WH_KEYBOARD_LL, WH_MOUSE_LL, WINDOW_EX_STYLE, WINDOW_STYLE, WM_KEYDOWN,
+    WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_QUIT, WM_RBUTTONDOWN,
+    WM_RBUTTONUP, WM_SYSKEYDOWN, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW,
 };
 
 use crate::error::Result;
 use crate::platform::state::BlockingHotkeys;
 use crate::types::{Key, KeyEvent, Modifiers};
 
-use super::keycode::{vk_to_key, vk_to_modifier};
+use super::keycode::{is_altgr_phantom_ctrl, map_key, vk_to_modifier};
 
 const HOOK_LOOP_TIMEOUT_MS: u32 = 10;
 
@@ -68,6 +67,10 @@ struct HookContext {
     event_sender: Sender<KeyEvent>,
     current_modifiers: Modifiers,
     blocking_hotkeys: Option<BlockingHotkeys>,
+    /// AltGr's phantom Left Ctrl is currently held. The hook drops the
+    /// phantom's own events, but GetAsyncKeyState still reports LCtrl as
+    /// down while AltGr is held, so reconciliation must not adopt it.
+    altgr_phantom_ctrl: bool,
 }
 
 thread_local! {
@@ -141,6 +144,24 @@ fn stale_modifiers(tracked: Modifiers, physical: Modifiers) -> Modifiers {
     (tracked & RECONCILABLE) & !physical
 }
 
+/// Physically-held modifiers we missed the press of and should adopt.
+///
+/// While AltGr's phantom Left Ctrl is held, CTRL_LEFT is excluded: it is
+/// physically down per GetAsyncKeyState, but the user only pressed Right
+/// Alt. A real Left Ctrl press during that window still sets CTRL_LEFT
+/// through its own hook event (which carries a non-phantom scancode).
+fn adoptable_modifiers(
+    tracked: Modifiers,
+    physical: Modifiers,
+    altgr_phantom_ctrl: bool,
+) -> Modifiers {
+    let mut adopt = physical & RECONCILABLE & !tracked;
+    if altgr_phantom_ctrl {
+        adopt &= !Modifiers::CTRL_LEFT;
+    }
+    adopt
+}
+
 /// Build the synthetic release events that clear `stale` from `tracked`, in
 /// MODIFIER_KEYS order. Each event carries the modifier set as it shrinks,
 /// exactly as if the keys had been released one by one.
@@ -181,6 +202,13 @@ fn release_events(tracked: Modifiers, stale: Modifiers) -> Vec<KeyEvent> {
 /// stamped per event.
 fn reconcile_modifiers(ctx: &mut HookContext) {
     let physical = physical_modifiers();
+    // Phantom Ctrl only exists while AltGr is held; if LCtrl reads as up,
+    // the phantom is gone (covers a phantom key-up swallowed by a secure
+    // desktop transition, which would otherwise suppress CTRL_LEFT adoption
+    // forever).
+    if ctx.altgr_phantom_ctrl && !physical.contains(Modifiers::CTRL_LEFT) {
+        ctx.altgr_phantom_ctrl = false;
+    }
     for event in release_events(
         ctx.current_modifiers,
         stale_modifiers(ctx.current_modifiers, physical),
@@ -188,7 +216,8 @@ fn reconcile_modifiers(ctx: &mut HookContext) {
         ctx.current_modifiers = event.modifiers;
         let _ = ctx.event_sender.send(event);
     }
-    ctx.current_modifiers |= physical & RECONCILABLE & !ctx.current_modifiers;
+    ctx.current_modifiers |=
+        adoptable_modifiers(ctx.current_modifiers, physical, ctx.altgr_phantom_ctrl);
 }
 
 /// Reconcile modifier state from the hook thread's message loop (used on
@@ -325,6 +354,7 @@ pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<Windows
                 event_sender: tx,
                 current_modifiers: Modifiers::empty(),
                 blocking_hotkeys: thread_blocking,
+                altgr_phantom_ctrl: false,
             });
         });
 
@@ -436,9 +466,20 @@ unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: 
             // Extract key information from KBDLLHOOKSTRUCT
             let kb_struct = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
             let vk_code = kb_struct.vkCode as u16;
+            let scan_code = kb_struct.scanCode;
             let is_extended = (kb_struct.flags.0 & LLKHF_EXTENDED.0) != 0;
 
             let is_key_down = matches!(wparam.0 as u32, WM_KEYDOWN | WM_SYSKEYDOWN);
+
+            // On AltGr layouts Windows synthesizes a Left Ctrl press/release
+            // around every Right Alt event (captured live on UK layout:
+            // identical timestamps, scancode 0x21D). Drop it entirely — no
+            // modifier update, no emit — so AltGr+key reads as OptRight
+            // only. The event is still passed down the hook chain.
+            if is_altgr_phantom_ctrl(vk_code, scan_code) {
+                ctx.altgr_phantom_ctrl = is_key_down;
+                return;
+            }
 
             // Check if this is a modifier key
             if let Some(modifier) = vk_to_modifier(vk_code) {
@@ -473,7 +514,7 @@ unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: 
                 // so reconciling there would fight the toggle logic above.)
                 reconcile_modifiers(ctx);
 
-                if let Some(key) = vk_to_key(vk_code, is_extended) {
+                if let Some(key) = map_key(vk_code, scan_code, is_extended) {
                     // Regular key event
                     should_block = should_block_hotkey(
                         &ctx.blocking_hotkeys,
@@ -751,5 +792,53 @@ mod tests {
     #[test]
     fn release_events_empty_when_nothing_stale() {
         assert!(release_events(Modifiers::CMD_LEFT, Modifiers::empty()).is_empty());
+    }
+
+    #[test]
+    fn adoption_picks_up_missed_presses() {
+        let adopt = adoptable_modifiers(
+            Modifiers::CTRL_LEFT,
+            Modifiers::CTRL_LEFT | Modifiers::SHIFT_LEFT,
+            false,
+        );
+        assert_eq!(adopt, Modifiers::SHIFT_LEFT);
+    }
+
+    #[test]
+    fn adoption_skips_ctrl_left_while_altgr_phantom_held() {
+        // AltGr held: GetAsyncKeyState reports LCtrl+RAlt down, but only
+        // OptRight reflects a user keypress. CTRL_LEFT must not be adopted.
+        let adopt = adoptable_modifiers(
+            Modifiers::OPT_RIGHT,
+            Modifiers::CTRL_LEFT | Modifiers::OPT_RIGHT,
+            true,
+        );
+        assert_eq!(adopt, Modifiers::empty());
+    }
+
+    #[test]
+    fn adoption_keeps_other_modifiers_while_altgr_phantom_held() {
+        // A genuinely-held Shift missed during a secure desktop transition
+        // is still adopted while the phantom flag is set.
+        let adopt = adoptable_modifiers(
+            Modifiers::OPT_RIGHT,
+            Modifiers::CTRL_LEFT | Modifiers::OPT_RIGHT | Modifiers::SHIFT_LEFT,
+            true,
+        );
+        assert_eq!(adopt, Modifiers::SHIFT_LEFT);
+    }
+
+    #[test]
+    fn phantom_flag_never_releases_a_tracked_ctrl() {
+        // User really holds LCtrl, then AltGr: CTRL_LEFT is tracked from its
+        // own event and physically down, so it must be neither stale nor
+        // re-adopted.
+        let tracked = Modifiers::CTRL_LEFT | Modifiers::OPT_RIGHT;
+        let physical = Modifiers::CTRL_LEFT | Modifiers::OPT_RIGHT;
+        assert_eq!(stale_modifiers(tracked, physical), Modifiers::empty());
+        assert_eq!(
+            adoptable_modifiers(tracked, physical, true),
+            Modifiers::empty()
+        );
     }
 }

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -71,6 +71,12 @@ pub enum Key {
     F18,
     F19,
     F20,
+    /// F21–F24 exist on Windows (VK 0x84–0x87) and in evdev; macOS virtual
+    /// keycodes stop at F20, so these are unreachable from macOS hardware.
+    F21,
+    F22,
+    F23,
+    F24,
 
     // Special keys
     Space,
@@ -219,6 +225,10 @@ impl fmt::Display for Key {
             Key::F18 => write!(f, "F18"),
             Key::F19 => write!(f, "F19"),
             Key::F20 => write!(f, "F20"),
+            Key::F21 => write!(f, "F21"),
+            Key::F22 => write!(f, "F22"),
+            Key::F23 => write!(f, "F23"),
+            Key::F24 => write!(f, "F24"),
             Key::Space => write!(f, "Space"),
             Key::Return => write!(f, "Return"),
             Key::Tab => write!(f, "Tab"),
@@ -350,6 +360,10 @@ impl FromStr for Key {
             "f18" => Ok(Key::F18),
             "f19" => Ok(Key::F19),
             "f20" => Ok(Key::F20),
+            "f21" => Ok(Key::F21),
+            "f22" => Ok(Key::F22),
+            "f23" => Ok(Key::F23),
+            "f24" => Ok(Key::F24),
 
             // Special keys
             "space" | " " => Ok(Key::Space),
@@ -454,6 +468,8 @@ mod tests {
         assert_eq!("F1".parse::<Key>().unwrap(), Key::F1);
         assert_eq!("f12".parse::<Key>().unwrap(), Key::F12);
         assert_eq!("F20".parse::<Key>().unwrap(), Key::F20);
+        assert_eq!("f21".parse::<Key>().unwrap(), Key::F21);
+        assert_eq!("F24".parse::<Key>().unwrap(), Key::F24);
     }
 
     #[test]
@@ -504,6 +520,10 @@ mod tests {
             Key::Num9,
             Key::F1,
             Key::F12,
+            Key::F21,
+            Key::F22,
+            Key::F23,
+            Key::F24,
             Key::Space,
             Key::Return,
             Key::Tab,

--- a/tests/synthetic_input.rs
+++ b/tests/synthetic_input.rs
@@ -19,9 +19,11 @@
 //! indistinguishable from hardware at the evdev layer) lands together with
 //! the in-tree evdev backend that replaces rdev.
 //!
-//! All injections use F20: it exists in the `Key` enum on both platforms
-//! and does nothing in terminals or the desktop environment, so a test run
-//! never types into or otherwise disturbs the session it runs in.
+//! Injections must never type into or otherwise disturb the session the
+//! tests run in: key-down/key-up pairs use F20 (exists in the `Key` enum on
+//! both platforms, does nothing in terminals or the desktop environment);
+//! keys that would type a character are injected as lone key-ups, which the
+//! low-level hook still observes but which generate no character.
 
 #![cfg(any(target_os = "macos", target_os = "windows"))]
 
@@ -93,7 +95,7 @@ mod windows_tests {
     use super::*;
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-        VK_F20,
+        KEYEVENTF_SCANCODE, VIRTUAL_KEY, VK_F20,
     };
 
     fn send_f20(key_up: bool) {
@@ -135,6 +137,59 @@ mod windows_tests {
         assert!(
             saw_key_event(&listener, Key::F20, false, Duration::from_secs(2)),
             "did not observe injected F20 key-up"
+        );
+    }
+
+    /// Inject a key-up by scancode only (wVk = 0, KEYEVENTF_SCANCODE):
+    /// Windows translates the scancode to a VK using the active layout,
+    /// exactly as a hardware key release would arrive at the hook. A lone
+    /// key-up generates no character, so nothing is typed into the session.
+    fn send_scancode_key_up(scan: u16) {
+        let input = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(0),
+                    wScan: scan,
+                    dwFlags: KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let sent = unsafe { SendInput(&[input], std::mem::size_of::<INPUT>() as i32) };
+        assert_eq!(sent, 1, "SendInput failed");
+    }
+
+    /// The grave and quote key *positions* must map to Grave and Quote no
+    /// matter which VK the active layout assigns them (cjpais/Handy#1516:
+    /// on UK, the apostrophe key sends VK_OEM_3 and used to report Grave).
+    ///
+    /// Windows translates the injected scancode through the active layout,
+    /// so this test proves layout independence when run under any layout
+    /// (verified live under both US and UK on the original dev machine).
+    /// It does not switch layouts itself: programmatic switching would
+    /// perturb the interactive session the test runs in and requires the
+    /// other layout to be installed, so it asserts per-scancode instead.
+    #[test]
+    #[ignore = "needs an interactive desktop session; run: cargo test --test synthetic_input -- --ignored"]
+    fn punctuation_scancodes_map_positionally() {
+        const SC_GRAVE: u16 = 0x29; // left of 1 (US `~, UK `¬)
+        const SC_QUOTE: u16 = 0x28; // right of ; (US '", UK '@)
+
+        let listener = KeyboardListener::new().expect("failed to spawn keyboard listener");
+        std::thread::sleep(Duration::from_millis(200));
+
+        send_scancode_key_up(SC_GRAVE);
+        assert!(
+            saw_key_event(&listener, Key::Grave, false, Duration::from_secs(2)),
+            "grave-position scancode 0x29 did not map to Key::Grave"
+        );
+
+        send_scancode_key_up(SC_QUOTE);
+        assert!(
+            saw_key_event(&listener, Key::Quote, false, Duration::from_secs(2)),
+            "quote-position scancode 0x28 did not map to Key::Quote"
         );
     }
 }


### PR DESCRIPTION
Should help with cjpais/Handy#1516 (UK layout: ` and ' keys both reported as Grave).

- Map punctuation keys by scancode (physical position) instead of VK_OEM_*, which move with the active layout. Letters/digits/etc. stay on VK mapping. unknown positions fall back to it.
- Drop the phantom Left Ctrl that Windows synthesizes around Right Alt on AltGr layouts (scancode 0x21D), so AltGr+key reads as OptRight only.
- Add F21–F24.

Tested on Windows under US and UK layouts.