### PR TITLE
replace event tap polling with callback recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "handy-keys"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bitflags",
  "block2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handy-keys"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "Cross-platform global keyboard shortcuts library"
 license = "MIT"
@@ -25,10 +25,6 @@ path = "examples/record_hotkey.rs"
 [[example]]
 name = "diagnostic"
 path = "examples/diagnostic.rs"
-
-[[example]]
-name = "ax_permission_probe"
-path = "examples/ax_permission_probe.rs"
 
 [dependencies]
 bitflags = { version = "2", features = ["serde"] }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -33,6 +33,10 @@ pub struct KeyboardListener {
     _thread_handle: Option<JoinHandle<()>>,
     running: Arc<AtomicBool>,
     blocking_hotkeys: Option<BlockingHotkeys>,
+    /// Backend-specific wakeup invoked on Drop after `running` is cleared.
+    /// macOS parks its listener thread in a CFRunLoop with no periodic
+    /// wakeups (see run_event_tap), so Drop must stop that loop explicitly.
+    stop_wakeup: Option<Box<dyn Fn() + Send>>,
 }
 
 impl KeyboardListener {
@@ -65,11 +69,13 @@ impl KeyboardListener {
         {
             use crate::platform::macos::listener;
             let state = listener::spawn(blocking_hotkeys)?;
+            let run_loop = state.run_loop;
             Ok(KeyboardListener {
                 event_receiver: state.event_receiver,
                 _thread_handle: state.thread_handle,
                 running: state.running,
                 blocking_hotkeys: state.blocking_hotkeys,
+                stop_wakeup: Some(Box::new(move || run_loop.stop())),
             })
         }
 
@@ -82,6 +88,7 @@ impl KeyboardListener {
                 _thread_handle: state.thread_handle,
                 running: state.running,
                 blocking_hotkeys: state.blocking_hotkeys,
+                stop_wakeup: None,
             })
         }
 
@@ -94,6 +101,7 @@ impl KeyboardListener {
                 _thread_handle: state.thread_handle,
                 running: state.running,
                 blocking_hotkeys: state.blocking_hotkeys,
+                stop_wakeup: None,
             })
         }
     }
@@ -140,9 +148,13 @@ impl Drop for KeyboardListener {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
 
-        // Every backend's event loop re-checks `running` at least every
-        // ~100ms, so the join below is short and shutdown is clean on all
-        // platforms.
+        // Wake the listener thread if the backend parks it (macOS stops the
+        // tap thread's CFRunLoop). Windows/Linux event loops re-check
+        // `running` at least every ~100ms on their own, so the join below is
+        // short and shutdown is clean on all platforms.
+        if let Some(wake) = &self.stop_wakeup {
+            wake();
+        }
         if let Some(handle) = self._thread_handle.take() {
             let _ = handle.join();
         }

--- a/src/platform/macos/listener.rs
+++ b/src/platform/macos/listener.rs
@@ -1,5 +1,6 @@
 //! macOS keyboard listener using CGEventTap
 
+use std::cell::Cell;
 use std::ffi::c_void;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicBool;
@@ -21,12 +22,49 @@ use crate::types::{Key, KeyEvent, Modifiers};
 use super::keycode::{flags_have_alpha_shift, flags_have_fn, keycode_to_key, keycode_to_modifier};
 use super::permissions::check_accessibility;
 
+/// The tap thread's run loop, handed back to the public listener so Drop can
+/// stop it. CFRunLoop is one of the documented thread-safe CF types; objc2
+/// doesn't mark it Send, hence the wrapper.
+pub(crate) struct TapRunLoop(CFRetained<CFRunLoop>);
+
+unsafe impl Send for TapRunLoop {}
+
+impl TapRunLoop {
+    /// Stop the tap thread's run loop. Callable from any thread.
+    ///
+    /// A bare CFRunLoopStop only affects a loop that is currently between
+    /// entry and exit — the stop flag lives in per-run data that is reset on
+    /// every entry — so a stop landing in the gap between the `running`
+    /// check and CFRunLoopRun entering would be silently lost and the tap
+    /// thread would park forever. Enqueue the stop as a run-loop block
+    /// instead: the block queue persists across entries, so the request
+    /// executes either right away (after the wake-up) or at the next entry.
+    /// Both behaviors verified empirically on macOS 26.5: a pre-entry
+    /// CFRunLoopStop is a no-op, a pre-entry enqueued block stops the loop
+    /// the moment it is entered.
+    pub(crate) fn stop(&self) {
+        let block = block2::StackBlock::new(|| {
+            if let Some(rl) = CFRunLoop::current() {
+                rl.stop();
+            }
+        });
+        unsafe {
+            self.0.perform_block(
+                objc2_core_foundation::kCFRunLoopCommonModes.map(|m| m.as_ref()),
+                Some(&block),
+            );
+        }
+        self.0.wake_up();
+    }
+}
+
 /// Internal listener state returned to KeyboardListener
 pub(crate) struct MacOSListenerState {
     pub event_receiver: Receiver<KeyEvent>,
     pub thread_handle: Option<JoinHandle<()>>,
     pub running: Arc<AtomicBool>,
     pub blocking_hotkeys: Option<BlockingHotkeys>,
+    pub run_loop: TapRunLoop,
 }
 
 /// Spawn a macOS keyboard listener using CGEventTap
@@ -39,8 +77,9 @@ pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<MacOSLi
     let state = Arc::new(Mutex::new(ListenerState::new(tx, blocking_hotkeys.clone())));
     let running = Arc::new(AtomicBool::new(true));
 
-    // Channel to communicate event tap creation success/failure
-    let (init_tx, init_rx) = mpsc::channel::<std::result::Result<(), String>>();
+    // Channel reporting event tap creation: the tap thread's run loop on
+    // success (needed to stop it later), or an error message.
+    let (init_tx, init_rx) = mpsc::channel::<std::result::Result<TapRunLoop, String>>();
 
     let thread_state = Arc::clone(&state);
     let thread_running = Arc::clone(&running);
@@ -50,10 +89,8 @@ pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<MacOSLi
     });
 
     // Wait for the event tap to be created
-    match init_rx.recv() {
-        Ok(Ok(())) => {
-            // Event tap created successfully
-        }
+    let run_loop = match init_rx.recv() {
+        Ok(Ok(run_loop)) => run_loop,
         Ok(Err(msg)) => {
             return Err(Error::EventTapCreationFailed(msg));
         }
@@ -62,13 +99,14 @@ pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<MacOSLi
                 "Event tap thread terminated unexpectedly".to_string(),
             ));
         }
-    }
+    };
 
     Ok(MacOSListenerState {
         event_receiver: rx,
         thread_handle: Some(handle),
         running,
         blocking_hotkeys,
+        run_loop,
     })
 }
 
@@ -109,6 +147,16 @@ fn reconcile_modifiers(current: &mut Modifiers, flags: CGEventFlags) {
     }
 }
 
+/// Context handed to the event tap callback through the refcon pointer.
+///
+/// `tap` is filled in right after `CGEventTapCreate` returns. The callback and
+/// `run_event_tap` execute on the same thread (callbacks only fire while that
+/// thread runs its run loop), so a plain `Cell` is sound.
+struct CallbackCtx {
+    state: Arc<Mutex<ListenerState>>,
+    tap: Cell<Option<NonNull<CFMachPort>>>,
+}
+
 /// The callback function for the event tap
 ///
 /// Returns NULL to block the event, or the event pointer to pass it through.
@@ -118,15 +166,39 @@ unsafe extern "C-unwind" fn event_tap_callback(
     event: NonNull<CGEvent>,
     user_info: *mut c_void,
 ) -> *mut CGEvent {
-    // Safety: user_info is our state pointer
-    let state = &*(user_info as *const Mutex<ListenerState>);
+    // Safety: user_info is the CallbackCtx owned by run_event_tap
+    let ctx = &*(user_info as *const CallbackCtx);
+
+    // Handle tap-disable pseudo-events before touching the state lock: macOS
+    // stops delivering real events until the tap is re-enabled, so recovery
+    // must not depend on the mutex being healthy. Re-enabling from the
+    // callback (rather than polling CGEventTapIsEnabled from the run loop) is
+    // the Apple-documented pattern and avoids recurring WindowServer RPCs —
+    // those leak kernel IPC vouchers and eventually panic the whole machine
+    // (cjpais/Handy#1827).
+    if matches!(
+        event_type,
+        CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
+    ) {
+        if let Some(tap) = ctx.tap.get() {
+            CGEvent::tap_enable(tap.as_ref(), true);
+        }
+        // Reconcile modifiers: we may have missed events while disabled.
+        if let Ok(mut state) = ctx.state.lock() {
+            reconcile_modifiers(
+                &mut state.current_modifiers,
+                CGEventSource::flags_state(CGEventSourceStateID::CombinedSessionState),
+            );
+        }
+        return event.as_ptr();
+    }
 
     let cg_event = event.as_ref();
     let flags = CGEvent::flags(Some(cg_event));
 
     let mut should_block = false;
 
-    if let Ok(mut state) = state.lock() {
+    if let Ok(mut state) = ctx.state.lock() {
         // Reconcile tracked modifiers against OS flags for non-FlagsChanged events.
         // On FlagsChanged, flags reflect the state *after* the current change, so
         // reconciling would fight with the toggle logic.
@@ -243,7 +315,7 @@ unsafe extern "C-unwind" fn event_tap_callback(
                         modifiers: new_modifiers,
                         key: None,
                         is_key_down,
-                        changed_modifier: changed_modifier,
+                        changed_modifier,
                     });
                 } else if keycode == 0x3F {
                     // FN key itself — tracked via flags, not keycode state
@@ -348,15 +420,8 @@ unsafe extern "C-unwind" fn event_tap_callback(
                     });
                 }
             }
-            CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput => {
-                // macOS disabled the tap (callback latency or user input).
-                // The run loop thread will re-enable it; reconcile modifiers
-                // now since we may have missed events while disabled.
-                reconcile_modifiers(
-                    &mut state.current_modifiers,
-                    CGEventSource::flags_state(CGEventSourceStateID::CombinedSessionState),
-                );
-            }
+            // TapDisabledByTimeout/TapDisabledByUserInput are handled (and
+            // returned from) before the state lock above.
             _ => {}
         }
     }
@@ -374,7 +439,7 @@ unsafe extern "C-unwind" fn event_tap_callback(
 fn run_event_tap(
     state: Arc<Mutex<ListenerState>>,
     running: Arc<AtomicBool>,
-    init_tx: Sender<std::result::Result<(), String>>,
+    init_tx: Sender<std::result::Result<TapRunLoop, String>>,
 ) {
     // Event types we want to monitor
     let event_mask: CGEventMask = (1 << CGEventType::KeyDown.0)
@@ -388,8 +453,11 @@ fn run_event_tap(
         | (1 << CGEventType::OtherMouseDown.0)
         | (1 << CGEventType::OtherMouseUp.0);
 
-    // Store state in a raw pointer for the callback
-    let state_ptr = Arc::into_raw(Arc::clone(&state)) as *mut c_void;
+    // Callback context, handed to the tap as a raw refcon pointer
+    let ctx_ptr = Box::into_raw(Box::new(CallbackCtx {
+        state: Arc::clone(&state),
+        tap: Cell::new(None),
+    }));
 
     let callback: CGEventTapCallBack = Some(event_tap_callback);
 
@@ -401,7 +469,7 @@ fn run_event_tap(
             CGEventTapOptions::Default,
             event_mask,
             callback,
-            state_ptr,
+            ctx_ptr as *mut c_void,
         )
     };
 
@@ -410,7 +478,7 @@ fn run_event_tap(
         None => {
             // Cleanup
             unsafe {
-                let _ = Arc::from_raw(state_ptr as *const Mutex<ListenerState>);
+                drop(Box::from_raw(ctx_ptr));
             }
             let _ = init_tx.send(Err(
                 "Failed to create event tap. Your terminal app may need accessibility permission in System Settings > Privacy & Security > Accessibility".to_string()
@@ -418,6 +486,11 @@ fn run_event_tap(
             return;
         }
     };
+
+    // Give the callback the tap port so it can re-enable on TapDisabledBy*
+    // pseudo-events. No race: callbacks only run on this thread's run loop,
+    // which hasn't started yet.
+    unsafe { (*ctx_ptr).tap.set(Some(NonNull::from(&*tap))) };
 
     // Create run loop source
     let source: Option<CFRetained<CFRunLoopSource>> =
@@ -428,7 +501,7 @@ fn run_event_tap(
         None => {
             unsafe {
                 CFMachPort::invalidate(&tap);
-                let _ = Arc::from_raw(state_ptr as *const Mutex<ListenerState>);
+                drop(Box::from_raw(ctx_ptr));
             }
             let _ = init_tx.send(Err("Failed to create run loop source".to_string()));
             return;
@@ -444,7 +517,7 @@ fn run_event_tap(
         None => {
             unsafe {
                 CFMachPort::invalidate(&tap);
-                let _ = Arc::from_raw(state_ptr as *const Mutex<ListenerState>);
+                drop(Box::from_raw(ctx_ptr));
             }
             let _ = init_tx.send(Err("Failed to get current run loop".to_string()));
             return;
@@ -456,21 +529,25 @@ fn run_event_tap(
     });
     CGEvent::tap_enable(&tap, true);
 
-    // Signal successful initialization
-    let _ = init_tx.send(Ok(()));
+    // Signal successful initialization, handing back this thread's run loop
+    // so KeyboardListener::drop can stop it.
+    let _ = init_tx.send(Ok(TapRunLoop(run_loop.clone())));
 
-    // Run the loop
+    // Park in the run loop: no periodic wakeups, no watchdog. v0.3.2 cycled
+    // CFRunLoopRunInMode every 100ms and polled CGEventTapIsEnabled each
+    // pass; that RPC leaked kernel IPC vouchers until macOS panicked with
+    // "Cannot grow ipc space beyond IVAC_ENTRIES_MAX" (cjpais/Handy#1827),
+    // and even the bare 100ms cycling cost ~10 mach messages/sec. Tap
+    // recovery is event-driven in event_tap_callback; shutdown goes through
+    // TapRunLoop::stop. Guarded by `running` in case the loop returns
+    // without a stop request; bail out if the tap's port died (e.g. the
+    // accessibility permission was revoked) so we don't spin on a dead
+    // source.
     while running.load(std::sync::atomic::Ordering::SeqCst) {
-        // Run for a short interval, then check if we should stop
-        CFRunLoop::run_in_mode(
-            unsafe { objc2_core_foundation::kCFRunLoopDefaultMode },
-            0.1, // 100ms timeout
-            true,
-        );
+        CFRunLoop::run();
 
-        // Re-enable tap if macOS disabled it due to callback latency
-        if !CGEvent::tap_is_enabled(&tap) {
-            CGEvent::tap_enable(&tap, true);
+        if !CFMachPort::is_valid(&tap) {
+            break;
         }
     }
 
@@ -481,6 +558,197 @@ fn run_event_tap(
     CGEvent::tap_enable(&tap, false);
     CFMachPort::invalidate(&tap);
     unsafe {
-        let _ = Arc::from_raw(state_ptr as *const Mutex<ListenerState>);
+        drop(Box::from_raw(ctx_ptr));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    use objc2_core_foundation::CFRunLoopTimer;
+
+    unsafe extern "C-unwind" fn noop_timer(_timer: *mut CFRunLoopTimer, _info: *mut c_void) {}
+
+    /// The stop request must survive being issued before the run loop has
+    /// been entered. A bare CFRunLoopStop is lost in that window (the stop
+    /// flag lives in per-run data reset on entry), which would park the tap
+    /// thread forever and hang KeyboardListener::drop. Needs no
+    /// accessibility permission, so it runs everywhere including CI.
+    #[test]
+    fn stop_requested_before_run_entry_is_not_lost() {
+        let (tx, rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let rl = CFRunLoop::current().expect("thread has a run loop");
+
+            // A far-future timer keeps the mode non-empty so run_in_mode
+            // actually blocks instead of returning Finished immediately.
+            let timer = unsafe {
+                CFRunLoopTimer::new(
+                    None,
+                    objc2_core_foundation::CFAbsoluteTimeGetCurrent() + 3600.0,
+                    0.0,
+                    0,
+                    0,
+                    Some(noop_timer),
+                    std::ptr::null_mut(),
+                )
+            }
+            .expect("create timer");
+            rl.add_timer(Some(&timer), unsafe {
+                objc2_core_foundation::kCFRunLoopDefaultMode
+            });
+
+            tx.send(TapRunLoop(rl.clone())).unwrap();
+
+            // Guarantee the main thread's stop lands while this thread is
+            // provably outside the run loop.
+            thread::sleep(Duration::from_millis(200));
+
+            let started = Instant::now();
+            // Bounded run: if the stop request was lost this returns at the
+            // 5s timeout and the elapsed assertion below fails, instead of
+            // hanging the test.
+            CFRunLoop::run_in_mode(
+                unsafe { objc2_core_foundation::kCFRunLoopDefaultMode },
+                5.0,
+                false,
+            );
+            started.elapsed()
+        });
+
+        let run_loop = rx.recv().expect("run loop handle");
+        run_loop.stop(); // lands before the thread enters the run loop
+
+        let elapsed = handle.join().expect("tap thread panicked");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "stop issued before run-loop entry was lost; loop ran for {elapsed:?}"
+        );
+    }
+
+    unsafe extern "C-unwind" fn noop_callback(
+        _proxy: CGEventTapProxy,
+        _event_type: CGEventType,
+        event: NonNull<CGEvent>,
+        _user_info: *mut c_void,
+    ) -> *mut CGEvent {
+        event.as_ptr()
+    }
+
+    /// A real (listen-only) event tap, or None when the test runner has no
+    /// accessibility permission (CI, unprivileged terminals) — tests skip.
+    fn create_test_tap() -> Option<CFRetained<CFMachPort>> {
+        if !check_accessibility() {
+            eprintln!("SKIPPED: accessibility permission not granted to the test runner");
+            return None;
+        }
+        unsafe {
+            CGEvent::tap_create(
+                CGEventTapLocation::SessionEventTap,
+                CGEventTapPlacement::HeadInsertEventTap,
+                CGEventTapOptions::ListenOnly,
+                1 << CGEventType::KeyDown.0,
+                Some(noop_callback),
+                std::ptr::null_mut(),
+            )
+        }
+    }
+
+    fn make_ctx(tap: &CFRetained<CFMachPort>) -> CallbackCtx {
+        let (tx, _rx) = mpsc::channel();
+        CallbackCtx {
+            state: Arc::new(Mutex::new(ListenerState::new(tx, None))),
+            tap: Cell::new(Some(NonNull::from(&**tap))),
+        }
+    }
+
+    fn deliver_tap_disabled(ctx: &CallbackCtx, event_type: CGEventType) {
+        let event = CGEvent::new(None).expect("failed to create CGEvent");
+        let returned = unsafe {
+            event_tap_callback(
+                std::ptr::null_mut(),
+                event_type,
+                NonNull::from(&*event),
+                ctx as *const CallbackCtx as *mut c_void,
+            )
+        };
+        assert_eq!(
+            returned,
+            NonNull::from(&*event).as_ptr(),
+            "pseudo-events must be passed through, not blocked"
+        );
+    }
+
+    /// Recovery is event-driven now (no polling watchdog): receiving a
+    /// TapDisabledBy* pseudo-event must re-enable the tap from the callback.
+    #[test]
+    fn tap_disabled_pseudo_event_reenables_tap() {
+        let Some(tap) = create_test_tap() else { return };
+
+        for event_type in [
+            CGEventType::TapDisabledByTimeout,
+            CGEventType::TapDisabledByUserInput,
+        ] {
+            let ctx = make_ctx(&tap);
+            CGEvent::tap_enable(&tap, false);
+            assert!(!CGEvent::tap_is_enabled(&tap));
+
+            deliver_tap_disabled(&ctx, event_type);
+
+            assert!(
+                CGEvent::tap_is_enabled(&tap),
+                "callback must re-enable the tap after {event_type:?}"
+            );
+        }
+    }
+
+    /// Re-enabling must not depend on the state mutex being healthy: a
+    /// poisoned mutex (a panic on some other thread holding it) must not
+    /// leave the tap permanently dead.
+    #[test]
+    fn tap_reenabled_even_with_poisoned_state_mutex() {
+        let Some(tap) = create_test_tap() else { return };
+
+        let ctx = make_ctx(&tap);
+        let state = Arc::clone(&ctx.state);
+        let _ = thread::spawn(move || {
+            let _guard = state.lock().unwrap();
+            panic!("poison the listener state mutex");
+        })
+        .join();
+        assert!(ctx.state.lock().is_err(), "mutex should be poisoned");
+
+        CGEvent::tap_enable(&tap, false);
+        assert!(!CGEvent::tap_is_enabled(&tap));
+
+        deliver_tap_disabled(&ctx, CGEventType::TapDisabledByTimeout);
+
+        assert!(
+            CGEvent::tap_is_enabled(&tap),
+            "re-enable must happen even when the state lock is unusable"
+        );
+    }
+
+    /// The pseudo-event handler must reconcile modifier state (the original
+    /// purpose of PR #4): stale tracked modifiers with no physically-held
+    /// keys must be cleared.
+    #[test]
+    fn tap_disabled_pseudo_event_reconciles_modifiers() {
+        let Some(tap) = create_test_tap() else { return };
+
+        let ctx = make_ctx(&tap);
+        ctx.state.lock().unwrap().current_modifiers = Modifiers::CTRL_LEFT | Modifiers::SHIFT_RIGHT;
+
+        deliver_tap_disabled(&ctx, CGEventType::TapDisabledByTimeout);
+
+        // No modifier keys are physically held while tests run, so
+        // reconciliation against OS flags must clear the stale state.
+        assert_eq!(
+            ctx.state.lock().unwrap().current_modifiers,
+            Modifiers::empty(),
+            "stale modifiers must be reconciled away on tap-disable"
+        );
     }
 }

--- a/tests/macos_ipc_quiescence.rs
+++ b/tests/macos_ipc_quiescence.rs
@@ -1,0 +1,132 @@
+//! Guards against recurring WindowServer IPC from the macOS listener.
+//!
+//! handy-keys ≤ 0.3.2 polled CGEventTapIsEnabled every 100ms from the event
+//! tap run loop. Each call is a synchronous mach RPC to WindowServer; on
+//! macOS 26 those RPCs leaked kernel IPC vouchers until the machine kernel-
+//! panicked with "Cannot grow ipc space beyond IVAC_ENTRIES_MAX"
+//! (cjpais/Handy#1827). The fix made tap recovery event-driven, so an idle
+//! listener must send (nearly) zero mach messages.
+//!
+//! This test measures the task-wide `messages_sent` counter around a 5-second
+//! idle window. The old watchdog alone produced ≥50 sends in that window;
+//! the threshold below fails loudly if recurring IPC ever creeps back in.
+//!
+//! Requires accessibility permission (skips itself otherwise). Avoid typing
+//! or clicking while it runs: every tapped input event costs a couple of
+//! mach messages and inflates the measurement.
+
+#![cfg(target_os = "macos")]
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use handy_keys::KeyboardListener;
+
+/// Tests in this file measure task-wide IPC counters, so they must not run
+/// concurrently with each other (cargo runs same-binary tests in parallel by
+/// default and the churn in `shutdown_is_prompt` would pollute the idle
+/// measurement).
+static SERIAL: Mutex<()> = Mutex::new(());
+
+/// `struct task_events_info` from <mach/task_info.h>.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct TaskEventsInfo {
+    faults: i32,
+    pageins: i32,
+    cow_faults: i32,
+    messages_sent: i32,
+    messages_received: i32,
+    syscalls_mach: i32,
+    syscalls_unix: i32,
+    csw: i32,
+}
+
+const TASK_EVENTS_INFO: u32 = 2;
+
+extern "C" {
+    static mach_task_self_: u32;
+    fn task_info(task: u32, flavor: u32, info: *mut i32, count: *mut u32) -> i32;
+}
+
+fn messages_sent() -> i64 {
+    let mut info = TaskEventsInfo::default();
+    let mut count = (std::mem::size_of::<TaskEventsInfo>() / 4) as u32;
+    let kr = unsafe {
+        task_info(
+            mach_task_self_,
+            TASK_EVENTS_INFO,
+            &mut info as *mut TaskEventsInfo as *mut i32,
+            &mut count,
+        )
+    };
+    assert_eq!(kr, 0, "task_info(TASK_EVENTS_INFO) failed: {kr}");
+    info.messages_sent as i64
+}
+
+#[test]
+fn idle_listener_sends_no_recurring_ipc() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+
+    let listener = match KeyboardListener::new() {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("SKIPPED: cannot create listener ({e})");
+            return;
+        }
+    };
+
+    // Let startup IPC (tap creation, first enable) settle.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Real keyboard/mouse activity during a window inflates the count (each
+    // tapped event costs mach messages), but nothing can deflate one — so
+    // the *minimum* over several windows filters desktop-activity noise
+    // without ever masking real recurring IPC: the old 10Hz watchdog put a
+    // ≥100-message floor under every window, far above the threshold.
+    let mut best = i64::MAX;
+    for window in 1..=3 {
+        let before = messages_sent();
+        std::thread::sleep(Duration::from_secs(5));
+        let delta = messages_sent() - before;
+        best = best.min(delta);
+        println!("window {window}: {delta} mach messages sent during 5s idle");
+        if best < 25 {
+            break;
+        }
+    }
+
+    assert!(
+        best < 25,
+        "idle listener sent ≥{best} mach messages in every 5s window — \
+         recurring IPC (e.g. a CGEventTapIsEnabled watchdog) has crept back \
+         in; that pattern kernel-panics macOS (cjpais/Handy#1827)"
+    );
+
+    drop(listener);
+}
+
+/// Shutdown must not hang: the listener thread parks in CFRunLoopRun with no
+/// periodic wakeups, so Drop's CFRunLoopStop is the only thing that ends it.
+/// Guards the stop-flag handoff (including the stop-before-run-entry race).
+#[test]
+fn shutdown_is_prompt() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+
+    for _ in 0..5 {
+        let listener = match KeyboardListener::new() {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("SKIPPED: cannot create listener ({e})");
+                return;
+            }
+        };
+        let start = std::time::Instant::now();
+        drop(listener);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "listener drop took {elapsed:?} — tap thread failed to stop promptly"
+        );
+    }
+}


### PR DESCRIPTION
Replaces continuous CGEventTapIsEnabled polling with event-driven recovery when macOS disables the tap. This avoids recurring WindowServer IPC that can exhaust kernel vouchers while preserving tap recovery and modifier reconciliation. Adds regression tests for idle IPC and race-free shutdown.