### PR TITLE
Add pause key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 windows = { version = "0.58", features = [
     "Win32_Foundation",
+    "Win32_System_Console",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_System_Threading",
 ] }

--- a/examples/diagnostic.rs
+++ b/examples/diagnostic.rs
@@ -21,6 +21,22 @@ use std::time::Instant;
 
 use handy_keys::KeyboardListener;
 
+// Ctrl+Pause arrives as Ctrl+Break in a Windows console, and the default handler
+// terminates the process. Swallow CTRL_BREAK_EVENT so the key reaches the hook.
+#[cfg(target_os = "windows")]
+fn prevent_ctrl_break_termination() {
+    use windows::Win32::Foundation::BOOL;
+    use windows::Win32::System::Console::{SetConsoleCtrlHandler, CTRL_BREAK_EVENT};
+
+    unsafe extern "system" fn handler(ctrl_type: u32) -> BOOL {
+        BOOL::from(ctrl_type == CTRL_BREAK_EVENT)
+    }
+
+    if let Err(e) = unsafe { SetConsoleCtrlHandler(Some(handler), true) } {
+        eprintln!("warning: could not install console Ctrl+Break handler: {e}");
+    }
+}
+
 fn main() -> handy_keys::Result<()> {
     println!(
         "handy-keys {} diagnostic — os={} arch={}",
@@ -30,6 +46,9 @@ fn main() -> handy_keys::Result<()> {
     );
     println!("Press keys to dump events. Ctrl+C to exit.");
     println!();
+
+    #[cfg(target_os = "windows")]
+    prevent_ctrl_break_termination();
 
     let listener = KeyboardListener::new()?;
     let start = Instant::now();

--- a/src/platform/linux/keycode.rs
+++ b/src/platform/linux/keycode.rs
@@ -88,6 +88,7 @@ pub fn key_code_to_key(code: KeyCode) -> Option<Key> {
         KeyCode::KEY_BACKSPACE => Some(Key::Delete),
         KeyCode::KEY_DELETE => Some(Key::ForwardDelete),
         KeyCode::KEY_INSERT => Some(Key::Insert),
+        KeyCode::KEY_PAUSE => Some(Key::Pause),
         KeyCode::KEY_HOME => Some(Key::Home),
         KeyCode::KEY_END => Some(Key::End),
         KeyCode::KEY_PAGEUP => Some(Key::PageUp),
@@ -180,6 +181,7 @@ mod tests {
         assert_eq!(key_code_to_key(KeyCode::KEY_SPACE), Some(Key::Space));
         assert_eq!(key_code_to_key(KeyCode::KEY_ENTER), Some(Key::Return));
         assert_eq!(key_code_to_key(KeyCode::KEY_INSERT), Some(Key::Insert));
+        assert_eq!(key_code_to_key(KeyCode::KEY_PAUSE), Some(Key::Pause));
     }
 
     #[test]

--- a/src/platform/windows/keycode.rs
+++ b/src/platform/windows/keycode.rs
@@ -484,13 +484,15 @@ mod tests {
 
     #[test]
     fn pause_and_ctrl_pause_map_to_pause() {
-        // Pause/Break key: virtual key VK_PAUSE (0x13), scancode 0x46.
-        assert_eq!(map_key(vk::PAUSE, 0x46, false), Some(Key::Pause));
+        // Pause/Break key: virtual key VK_PAUSE (0x13), scancode 0x45
+        // (make sequence E1 1D 45 — E1-prefixed, so not extended).
+        assert_eq!(map_key(vk::PAUSE, 0x45, false), Some(Key::Pause));
         // Windows quirk: while Ctrl is held, it rewrites Pause's virtual key
         // from VK_PAUSE (0x13) to VK_CANCEL (0x03), an old behavior of using
-        // Ctrl+Break to cancel. Mapping VK_CANCEL back to Pause lets a
+        // Ctrl+Break to cancel. The scancode changes too: E0 46, so 0x46
+        // with the extended flag set. Mapping VK_CANCEL back to Pause lets a
         // Ctrl+Pause hotkey resolve to Key::Pause with the held Ctrl modifier.
-        assert_eq!(map_key(vk::CANCEL, 0x46, false), Some(Key::Pause));
+        assert_eq!(map_key(vk::CANCEL, 0x46, true), Some(Key::Pause));
     }
 
     #[test]

--- a/src/platform/windows/keycode.rs
+++ b/src/platform/windows/keycode.rs
@@ -6,12 +6,14 @@ use crate::types::{Key, Modifiers};
 #[allow(dead_code)]
 mod vk {
     // Control keys
+    pub const CANCEL: u16 = 0x03; // Ctrl+Pause / Ctrl+Break
     pub const BACK: u16 = 0x08;
     pub const TAB: u16 = 0x09;
     pub const RETURN: u16 = 0x0D;
     pub const SHIFT: u16 = 0x10;
     pub const CONTROL: u16 = 0x11;
     pub const MENU: u16 = 0x12; // Alt
+    pub const PAUSE: u16 = 0x13; // Pause/Break
     pub const CAPITAL: u16 = 0x14; // Caps Lock
     pub const ESCAPE: u16 = 0x1B;
     pub const SPACE: u16 = 0x20;
@@ -320,6 +322,8 @@ fn vk_to_key(vk_code: u16, is_extended: bool) -> Option<Key> {
         vk::BACK => Some(Key::Delete), // Backspace
         vk::DELETE => Some(Key::ForwardDelete),
         vk::INSERT => Some(Key::Insert),
+        vk::PAUSE => Some(Key::Pause),
+        vk::CANCEL => Some(Key::Pause), // Ctrl+Pause
         vk::TAB => Some(Key::Tab),
         vk::ESCAPE => Some(Key::Escape),
         vk::SPACE => Some(Key::Space),
@@ -476,6 +480,17 @@ mod tests {
         assert_eq!(map_key(vk::F22, 0, false), Some(Key::F22));
         assert_eq!(map_key(vk::F23, 0, false), Some(Key::F23));
         assert_eq!(map_key(vk::F24, 0, false), Some(Key::F24));
+    }
+
+    #[test]
+    fn pause_and_ctrl_pause_map_to_pause() {
+        // Pause/Break key: virtual key VK_PAUSE (0x13), scancode 0x46.
+        assert_eq!(map_key(vk::PAUSE, 0x46, false), Some(Key::Pause));
+        // Windows quirk: while Ctrl is held, it rewrites Pause's virtual key
+        // from VK_PAUSE (0x13) to VK_CANCEL (0x03), an old behavior of using
+        // Ctrl+Break to cancel. Mapping VK_CANCEL back to Pause lets a
+        // Ctrl+Pause hotkey resolve to Key::Pause with the held Ctrl modifier.
+        assert_eq!(map_key(vk::CANCEL, 0x46, false), Some(Key::Pause));
     }
 
     #[test]

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -92,6 +92,8 @@ pub enum Key {
     Delete,
     ForwardDelete,
     Insert,
+    /// Pause/Break — PC keyboards only; macOS has no keycode for it.
+    Pause,
     Home,
     End,
     PageUp,
@@ -246,6 +248,7 @@ impl fmt::Display for Key {
             Key::Delete => write!(f, "Delete"),
             Key::ForwardDelete => write!(f, "ForwardDelete"),
             Key::Insert => write!(f, "Insert"),
+            Key::Pause => write!(f, "Pause"),
             Key::Home => write!(f, "Home"),
             Key::End => write!(f, "End"),
             Key::PageUp => write!(f, "PageUp"),
@@ -389,6 +392,7 @@ impl FromStr for Key {
             "delete" | "backspace" => Ok(Key::Delete),
             "forwarddelete" | "del" => Ok(Key::ForwardDelete),
             "insert" | "ins" => Ok(Key::Insert),
+            "pause" | "break" => Ok(Key::Pause),
             "home" => Ok(Key::Home),
             "end" => Ok(Key::End),
             "pageup" => Ok(Key::PageUp),
@@ -544,6 +548,7 @@ mod tests {
             Key::Return,
             Key::Tab,
             Key::Escape,
+            Key::Pause,
             Key::LeftArrow,
             Key::RightArrow,
             Key::KeypadPlus,
@@ -589,5 +594,13 @@ mod tests {
         assert_eq!("stop".parse::<Key>().unwrap(), Key::Stop);
         assert_eq!("prevtrack".parse::<Key>().unwrap(), Key::PrevTrack);
         assert_eq!("nexttrack".parse::<Key>().unwrap(), Key::NextTrack);
+    }
+
+    #[test]
+    fn parse_pause_aliases() {
+        // Pause and Break share one physical key on PC hardware.
+        assert_eq!("pause".parse::<Key>().unwrap(), Key::Pause);
+        assert_eq!("Pause".parse::<Key>().unwrap(), Key::Pause);
+        assert_eq!("break".parse::<Key>().unwrap(), Key::Pause);
     }
 }


### PR DESCRIPTION
Adds support for Pause key and special handling for Ctrl+Pause on windows. Fixes #33 

Adds the Pause/Break key to the Key enum so consumers can register it as a hotkey.

Ctrl+Pause / Ctrl+Break is a Windows special case: holding Ctrl rewrites Pause's virtual code from `VK_PAUSE` (0x13) to `VK_CANCEL` (0x03).